### PR TITLE
feat(ui): implement custom confirmation dialog and improve state management

### DIFF
--- a/.cursorrules
+++ b/.cursorrules
@@ -1,0 +1,39 @@
+# Cursor AI Preferences for this Project
+
+## Commit Message Format
+
+All Git commit messages must follow the [Conventional Changelog](https://github.com/conventional-changelog/conventional-changelog) format:
+
+```text
+<type>(<scope>): <subject>
+
+<body>
+
+<footer>
+```
+
+Where:
+
+- **type**: The type of change (feat, fix, docs, style, refactor, perf, test, chore, etc.)
+- **scope**: Optional - the area of the codebase affected (e.g., ui, core, handlers)
+- **subject**: Short description in imperative mood (e.g., "add feature" not "added feature")
+- **body**: Optional - detailed explanation of the change
+- **footer**: Optional - references to issues, breaking changes, etc.
+
+Example:
+
+```text
+feat(ui): add dark mode toggle
+
+Implement dark mode support with toggle in settings panel.
+Uses system preferences as default.
+
+Closes #123
+```
+
+## Commit Behavior
+
+- **DO NOT** automatically commit changes
+- Always let the user review changes first before committing
+- Only commit when explicitly requested by the user
+- When committing, use the Conventional Changelog format described above

--- a/src-tauri/capabilities/default.json
+++ b/src-tauri/capabilities/default.json
@@ -6,7 +6,8 @@
   "permissions": [
     "core:default",
     "opener:default",
-    "dialog:default",
+    "dialog:allow-open",
+    "dialog:allow-save",
     "macos-permissions:default",
     "store:default"
   ]

--- a/src/core/browse.ts
+++ b/src/core/browse.ts
@@ -83,6 +83,11 @@ export async function browseImages(path: string): Promise<void> {
   state.currentModalIndex = -1;
   state.currentDirectory = path;
   
+  // Clear categories and hotkeys state before loading new config
+  state.categories = [];
+  state.imageCategories.clear();
+  state.hotkeys = [];
+  
   // Reset config file path to default when browsing new directory
   if (elements.configFilePathInput) {
     elements.configFilePathInput.value = "";
@@ -170,6 +175,12 @@ export async function browseImages(path: string): Promise<void> {
     
     // Load categories and hotkeys for this directory
     await loadHitoConfig();
+    
+    // Render category and hotkey lists (will show empty state if no config)
+    const { renderCategoryList } = await import("../ui/categories.js");
+    const { renderHotkeyList } = await import("../ui/hotkeys.js");
+    renderCategoryList();
+    renderHotkeyList();
     
     // Show sidebar toggle button when browsing a directory
     if (elements.hotkeySidebarToggle) {

--- a/src/main.ts
+++ b/src/main.ts
@@ -39,7 +39,7 @@ function initializeElements(): void {
   elements.configFilePathInput = querySelector<HTMLInputElement>("#config-file-path");
 }
 
-function resetToHome(): void {
+async function resetToHome(): Promise<void> {
   clearImageGrid();
   expandDropZone();
   clearError();
@@ -63,6 +63,7 @@ function resetToHome(): void {
   state.configFilePath = "";
   state.categories = [];
   state.imageCategories.clear();
+  state.hotkeys = [];
   
   // Reset config file path input
   if (elements.configFilePathInput) {
@@ -70,7 +71,10 @@ function resetToHome(): void {
     elements.configFilePathInput.placeholder = ".hito.json";
   }
   
-  // Hide sidebar toggle button on home screen
+  // Close and hide sidebar on home screen
+  const { closeHotkeySidebar } = await import("./ui/hotkeys.js");
+  closeHotkeySidebar();
+  
   if (elements.hotkeySidebarToggle) {
     elements.hotkeySidebarToggle.style.display = "none";
   }

--- a/src/styles.css
+++ b/src/styles.css
@@ -1484,3 +1484,136 @@ body:has(.hotkey-sidebar.open) .hotkey-sidebar-toggle {
   margin-bottom: 8px;
   display: none;
 }
+
+/* Confirmation Dialog */
+.confirm-dialog-overlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background-color: rgba(0, 0, 0, 0.7);
+  z-index: 1004;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  backdrop-filter: blur(4px);
+  animation: fadeIn 0.2s ease-out;
+}
+
+@keyframes fadeIn {
+  from {
+    opacity: 0;
+  }
+  to {
+    opacity: 1;
+  }
+}
+
+.confirm-dialog {
+  background-color: rgba(30, 30, 30, 0.98);
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  border-radius: 12px;
+  width: 90%;
+  max-width: 400px;
+  box-shadow: 0 8px 32px rgba(0, 0, 0, 0.5);
+  display: flex;
+  flex-direction: column;
+  box-sizing: border-box;
+  overflow: hidden;
+  animation: slideIn 0.2s ease-out;
+}
+
+@keyframes slideIn {
+  from {
+    transform: translateY(-20px);
+    opacity: 0;
+  }
+  to {
+    transform: translateY(0);
+    opacity: 1;
+  }
+}
+
+.confirm-dialog-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 20px;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.1);
+}
+
+.confirm-dialog-header h3 {
+  margin: 0;
+  color: #f1f1f1;
+  font-size: 1.3em;
+}
+
+.confirm-dialog-close {
+  background: none;
+  border: none;
+  color: #f1f1f1;
+  font-size: 28px;
+  cursor: pointer;
+  padding: 0;
+  width: 32px;
+  height: 32px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 4px;
+  transition: background-color 0.2s;
+}
+
+.confirm-dialog-close:hover {
+  background-color: rgba(255, 255, 255, 0.1);
+}
+
+.confirm-dialog-body {
+  padding: 24px 20px;
+  color: #ccc;
+  font-size: 1em;
+  line-height: 1.6;
+}
+
+.confirm-dialog-footer {
+  padding: 20px;
+  border-top: 1px solid rgba(255, 255, 255, 0.1);
+  display: flex;
+  justify-content: flex-end;
+  gap: 12px;
+}
+
+.confirm-dialog-btn {
+  padding: 10px 24px;
+  border-radius: 6px;
+  border: none;
+  cursor: pointer;
+  font-size: 1em;
+  font-weight: 500;
+  transition: all 0.2s;
+}
+
+.confirm-dialog-cancel {
+  background-color: rgba(255, 255, 255, 0.1);
+  color: #f1f1f1;
+}
+
+.confirm-dialog-cancel:hover {
+  background-color: rgba(255, 255, 255, 0.2);
+}
+
+.confirm-dialog-confirm {
+  background-color: #22c55e;
+  color: white;
+}
+
+.confirm-dialog-confirm:hover {
+  background-color: #16a34a;
+}
+
+.confirm-dialog-confirm:focus,
+.confirm-dialog-cancel:focus {
+  outline: 2px solid #22c55e;
+  outline-offset: 2px;
+}

--- a/src/utils/dialog.ts
+++ b/src/utils/dialog.ts
@@ -6,3 +6,100 @@ export function open(options?: { directory?: boolean; multiple?: boolean; title?
   return window.__TAURI__.dialog.open(options);
 }
 
+/**
+ * Show a custom confirmation dialog matching the app's design.
+ * @param message - The message to display
+ * @param options - Optional configuration (title)
+ * @returns Promise that resolves to true if user confirmed, false if canceled
+ */
+export async function confirm(
+  message: string,
+  options?: { title?: string }
+): Promise<boolean> {
+  return new Promise<boolean>((resolve) => {
+    // Create overlay
+    const overlay = document.createElement("div");
+    overlay.className = "confirm-dialog-overlay";
+    
+    // Create dialog
+    const dialog = document.createElement("div");
+    dialog.className = "confirm-dialog";
+    
+    // Create header
+    const header = document.createElement("div");
+    header.className = "confirm-dialog-header";
+    
+    const title = document.createElement("h3");
+    title.textContent = options?.title || "Confirm";
+    header.appendChild(title);
+    
+    const closeBtn = document.createElement("button");
+    closeBtn.className = "confirm-dialog-close";
+    closeBtn.textContent = "×";
+    closeBtn.setAttribute("aria-label", "Close");
+    closeBtn.onclick = () => {
+      overlay.remove();
+      resolve(false);
+    };
+    header.appendChild(closeBtn);
+    
+    // Create body
+    const body = document.createElement("div");
+    body.className = "confirm-dialog-body";
+    body.textContent = message;
+    
+    // Create footer
+    const footer = document.createElement("div");
+    footer.className = "confirm-dialog-footer";
+    
+    const cancelBtn = document.createElement("button");
+    cancelBtn.className = "confirm-dialog-btn confirm-dialog-cancel";
+    cancelBtn.textContent = "Cancel";
+    cancelBtn.onclick = () => {
+      overlay.remove();
+      resolve(false);
+    };
+    
+    const confirmBtn = document.createElement("button");
+    confirmBtn.className = "confirm-dialog-btn confirm-dialog-confirm";
+    confirmBtn.textContent = "OK";
+    confirmBtn.onclick = () => {
+      overlay.remove();
+      resolve(true);
+    };
+    
+    footer.appendChild(cancelBtn);
+    footer.appendChild(confirmBtn);
+    
+    // Assemble dialog
+    dialog.appendChild(header);
+    dialog.appendChild(body);
+    dialog.appendChild(footer);
+    overlay.appendChild(dialog);
+    
+    // Add to document
+    document.body.appendChild(overlay);
+    
+    // Close on overlay click
+    overlay.onclick = (e) => {
+      if (e.target === overlay) {
+        overlay.remove();
+        resolve(false);
+      }
+    };
+    
+    // Close on Escape key
+    const handleEscape = (e: KeyboardEvent) => {
+      if (e.key === "Escape") {
+        overlay.remove();
+        document.removeEventListener("keydown", handleEscape);
+        resolve(false);
+      }
+    };
+    document.addEventListener("keydown", handleEscape);
+    
+    // Focus confirm button
+    setTimeout(() => confirmBtn.focus(), 100);
+  });
+}
+


### PR DESCRIPTION
Replace Tauri native dialog with custom confirmation modal that matches app design. Fix delete confirmation flow and ensure proper state cleanup when navigating.

- Add custom confirmation dialog with dark theme matching app design
- Remove icon-based native system dialogs on macOS
- Fix delete buttons to properly await user confirmation
- Close sidebar and clear state when returning to home screen
- Clear categories/hotkeys state when opening new folders
- Clean up wired hotkeys when deleting categories
- Remove unused @tauri-apps/plugin-dialog npm package
- Optimize dialog permissions to only allow file/folder picker
- Add .cursorrules for Conventional Changelog commit format

Close #10 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added confirmation dialogs when deleting categories and hotkeys to prevent accidental data loss.

* **UI/UX Improvements**
  * Enhanced dialog styling with fade-in animations and improved visual presentation.

* **Bug Fixes**
  * Improved state management during directory navigation to properly clear and reload categories and hotkeys settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->