### PR TITLE
refactor: migrate state management to Jotai

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "@tauri-apps/api": "^2.9.0",
     "@tauri-apps/plugin-store": "^2",
     "fast-deep-equal": "^3.1.3",
+    "jotai": "^2.15.1",
     "react": "^19.2.0",
     "react-dom": "^19.2.0"
   }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -17,6 +17,9 @@ importers:
       fast-deep-equal:
         specifier: ^3.1.3
         version: 3.1.3
+      jotai:
+        specifier: ^2.15.1
+        version: 2.15.1(@babel/core@7.28.5)(@babel/template@7.27.2)(@types/react@19.2.6)(react@19.2.0)
       react:
         specifier: ^19.2.0
         version: 19.2.0
@@ -925,6 +928,24 @@ packages:
 
   jackspeak@3.4.3:
     resolution: {integrity: sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==}
+
+  jotai@2.15.1:
+    resolution: {integrity: sha512-yHT1HAZ3ba2Q8wgaUQ+xfBzEtcS8ie687I8XVCBinfg4bNniyqLIN+utPXWKQE93LMF5fPbQSVRZqgpcN5yd6Q==}
+    engines: {node: '>=12.20.0'}
+    peerDependencies:
+      '@babel/core': '>=7.0.0'
+      '@babel/template': '>=7.0.0'
+      '@types/react': '>=17.0.0'
+      react: '>=17.0.0'
+    peerDependenciesMeta:
+      '@babel/core':
+        optional: true
+      '@babel/template':
+        optional: true
+      '@types/react':
+        optional: true
+      react:
+        optional: true
 
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
@@ -2133,6 +2154,13 @@ snapshots:
       '@isaacs/cliui': 8.0.2
     optionalDependencies:
       '@pkgjs/parseargs': 0.11.0
+
+  jotai@2.15.1(@babel/core@7.28.5)(@babel/template@7.27.2)(@types/react@19.2.6)(react@19.2.0):
+    optionalDependencies:
+      '@babel/core': 7.28.5
+      '@babel/template': 7.27.2
+      '@types/react': 19.2.6
+      react: 19.2.0
 
   js-tokens@4.0.0: {}
 

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -4,7 +4,7 @@ version = 4
 
 [[package]]
 name = "Hito"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "base64 0.22.1",
  "chrono",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "Hito"
-version = "0.3.1"
+version = "0.3.2"
 description = "A Tauri App for Human Intelligence Tasks organizer"
 authors = ["iomz@sazanka.io"]
 edition = "2021"

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,7 +1,8 @@
-import React, { useEffect, useState } from "react";
+import React, { useEffect, useMemo } from "react";
+import { useAtomValue } from "jotai";
 import { setupDocumentDragHandlers, setupTauriDragEvents } from "./handlers/dragDrop";
 import { setupKeyboardHandlers } from "./handlers/keyboard";
-import { state } from "./state";
+import { allImagePathsAtom, allDirectoryPathsAtom } from "./state";
 import { DropZone } from "./components/DropZone";
 import { CurrentPath } from "./components/CurrentPath";
 import { ErrorMessage } from "./components/ErrorMessage";
@@ -18,26 +19,15 @@ import { Logo } from "./components/Logo";
 import { CUSTOM_DRAG_EVENTS } from "./constants";
 
 function App() {
-  const [hasContent, setHasContent] = useState(false);
-  const [isDragOver, setIsDragOver] = useState(false);
+  const allImagePaths = useAtomValue(allImagePathsAtom);
+  const allDirectoryPaths = useAtomValue(allDirectoryPathsAtom);
+  const [isDragOver, setIsDragOver] = React.useState(false);
 
-  // Subscribe to state changes to reactively show/hide ImageGrid
-  useEffect(() => {
-    const hasContent = () => Boolean(
-      Array.isArray(state.allImagePaths) && state.allImagePaths.length > 0 ||
-      Array.isArray(state.allDirectoryPaths) && state.allDirectoryPaths.length > 0
-    );
-    
-    // One-time initial sync
-    setHasContent(hasContent());
-    
-    // Subscribe to state changes
-    const unsubscribe = state.subscribe(() => {
-      setHasContent(hasContent());
-    });
-    
-    return unsubscribe;
-  }, []);
+  // Compute hasContent reactively from atoms
+  const hasContent = useMemo(() => Boolean(
+    Array.isArray(allImagePaths) && allImagePaths.length > 0 ||
+    Array.isArray(allDirectoryPaths) && allDirectoryPaths.length > 0
+  ), [allImagePaths, allDirectoryPaths]);
 
   useEffect(() => {
     // Setup all event handlers after DOM is ready

--- a/src/components/CategoryDialog.tsx
+++ b/src/components/CategoryDialog.tsx
@@ -147,11 +147,18 @@ export function CategoryDialog() {
       setCategories([...categories, newCategory]);
     }
     
-    await saveHitoConfig();
-    
-    // Close dialog
-    setCategoryDialogVisible(false);
-    setCategoryDialogCategory(undefined);
+    try {
+      await saveHitoConfig();
+      
+      // Close dialog only if save succeeds
+      setCategoryDialogVisible(false);
+      setCategoryDialogCategory(undefined);
+    } catch (error) {
+      // Show error to user and keep dialog open so they can retry or cancel
+      const errorMessage = error instanceof Error ? error.message : String(error);
+      setErrorMessage(`Failed to save category: ${errorMessage}`);
+      setShowError(true);
+    }
   }, [name, color, editingCategory, categories, setCategories, setCategoryDialogVisible, setCategoryDialogCategory]);
 
   const handleOverlayClick = (e: React.MouseEvent<HTMLDivElement>) => {

--- a/src/components/CategoryList.tsx
+++ b/src/components/CategoryList.tsx
@@ -1,25 +1,12 @@
-import React, { useEffect, useState } from "react";
-import { state } from "../state";
+import React from "react";
+import { useAtomValue } from "jotai";
+import { categoriesAtom, imageCategoriesAtom } from "../state";
 import type { Category, CategoryAssignment } from "../types";
 import { showCategoryDialog, deleteCategory } from "../ui/categories";
 
 export function CategoryList() {
-  const [categories, setCategories] = useState<Category[]>([]);
-  const [imageCategories, setImageCategories] = useState<Map<string, CategoryAssignment[]>>(new Map());
-
-  // Subscribe to state changes instead of polling
-  useEffect(() => {
-    const unsubscribe = state.subscribe(() => {
-      setCategories(Array.isArray(state.categories) ? [...state.categories] : []);
-      setImageCategories(new Map(state.imageCategories));
-    });
-    
-    // Initialize
-    setCategories(Array.isArray(state.categories) ? [...state.categories] : []);
-    setImageCategories(new Map(state.imageCategories));
-    
-    return unsubscribe;
-  }, []);
+  const categories = useAtomValue(categoriesAtom);
+  const imageCategories = useAtomValue(imageCategoriesAtom);
 
   // Calculate image count for a category
   const getImageCount = (categoryId: string): number => {

--- a/src/components/ConfigFileInput.tsx
+++ b/src/components/ConfigFileInput.tsx
@@ -1,34 +1,14 @@
-import React, { useEffect, useState, useRef } from "react";
-import { state } from "../state";
+import React from "react";
+import { useAtomValue, useSetAtom } from "jotai";
+import { configFilePathAtom } from "../state";
 
 export function ConfigFileInput() {
-  // Initialize local state from global state once
-  const [value, setValue] = useState(state.configFilePath);
-  const valueRef = useRef(value);
-
-  // Keep ref in sync with state
-  useEffect(() => {
-    valueRef.current = value;
-  }, [value]);
-
-  useEffect(() => {
-    // Subscribe to state changes to sync when configFilePath changes externally
-    const unsubscribe = state.subscribe(() => {
-      // Only update if the change came from outside (not from our own handleChange)
-      if (state.configFilePath !== valueRef.current) {
-        setValue(state.configFilePath);
-      }
-    });
-
-    return unsubscribe;
-  }, []); // Empty deps - subscribe once and never recreate
+  const value = useAtomValue(configFilePathAtom);
+  const setConfigFilePath = useSetAtom(configFilePathAtom);
 
   const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const newValue = e.target.value.trim();
-    setValue(newValue);
-    valueRef.current = newValue; // Update ref immediately to prevent subscription from triggering redundant update
-    state.configFilePath = newValue;
-    state.notify(); // Notify other subscribers of the change
+    setConfigFilePath(newValue);
   };
 
   return (

--- a/src/components/CurrentImageCategories.tsx
+++ b/src/components/CurrentImageCategories.tsx
@@ -1,5 +1,6 @@
-import React, { useEffect, useState } from "react";
-import { state } from "../state";
+import React from "react";
+import { useAtomValue } from "jotai";
+import { currentModalImagePathAtom, categoriesAtom, imageCategoriesAtom } from "../state";
 import type { Category, CategoryAssignment } from "../types";
 
 function getContrastColor(hexColor: string): string {
@@ -19,28 +20,9 @@ function getContrastColor(hexColor: string): string {
 }
 
 export function CurrentImageCategories() {
-  const [categories, setCategories] = useState<Category[]>([]);
-  const [imageCategories, setImageCategories] = useState<Map<string, CategoryAssignment[]>>(new Map());
-  const [currentImagePath, setCurrentImagePath] = useState<string>("");
-
-  // Subscribe to state changes
-  useEffect(() => {
-    // One-time initial sync
-    const modalImagePath = state.currentModalImagePath;
-    setCurrentImagePath(modalImagePath || "");
-    setCategories([...state.categories]);
-    setImageCategories(new Map(state.imageCategories));
-    
-    // Subscribe to state changes
-    const unsubscribe = state.subscribe(() => {
-      const newModalImagePath = state.currentModalImagePath;
-      setCurrentImagePath(newModalImagePath || "");
-      setCategories([...state.categories]);
-      setImageCategories(new Map(state.imageCategories));
-    });
-    
-    return unsubscribe;
-  }, []);
+  const currentImagePath = useAtomValue(currentModalImagePathAtom);
+  const categories = useAtomValue(categoriesAtom);
+  const imageCategories = useAtomValue(imageCategoriesAtom);
 
   const handleToggleCategory = async (categoryId: string) => {
     if (!currentImagePath) return;

--- a/src/components/CurrentImageCategories.tsx
+++ b/src/components/CurrentImageCategories.tsx
@@ -2,22 +2,7 @@ import React from "react";
 import { useAtomValue } from "jotai";
 import { currentModalImagePathAtom, categoriesAtom, imageCategoriesAtom } from "../state";
 import type { Category, CategoryAssignment } from "../types";
-
-function getContrastColor(hexColor: string): string {
-  // Remove # if present
-  const hex = hexColor.replace("#", "");
-
-  // Convert to RGB
-  const r = parseInt(hex.substring(0, 2), 16);
-  const g = parseInt(hex.substring(2, 4), 16);
-  const b = parseInt(hex.substring(4, 6), 16);
-
-  // Calculate luminance
-  const luminance = (0.299 * r + 0.587 * g + 0.114 * b) / 255;
-
-  // Return black for light colors, white for dark colors
-  return luminance > 0.5 ? "#000000" : "#ffffff";
-}
+import { getContrastColor } from "../utils/colors";
 
 export function CurrentImageCategories() {
   const currentImagePath = useAtomValue(currentModalImagePathAtom);

--- a/src/components/CurrentPath.tsx
+++ b/src/components/CurrentPath.tsx
@@ -1,24 +1,12 @@
-import React, { useEffect, useState } from "react";
-import { state } from "../state";
+import React, { useMemo } from "react";
+import { useAtomValue } from "jotai";
+import { currentDirectoryAtom } from "../state";
 import { normalizePath } from "../utils/state";
 import { handleFolder } from "../handlers/dragDrop";
 
 export function CurrentPath() {
-  const [currentDirectory, setCurrentDirectory] = useState("");
-  const [isVisible, setIsVisible] = useState(false);
-
-  useEffect(() => {
-    // One-time initial sync
-    setCurrentDirectory(state.currentDirectory);
-    setIsVisible(state.currentDirectory.length > 0);
-    
-    // Subscribe to state changes
-    const unsubscribe = state.subscribe(() => {
-      setCurrentDirectory(state.currentDirectory);
-      setIsVisible(state.currentDirectory.length > 0);
-    });
-    return unsubscribe;
-  }, []);
+  const currentDirectory = useAtomValue(currentDirectoryAtom);
+  const isVisible = useMemo(() => currentDirectory.length > 0, [currentDirectory]);
 
   if (!isVisible || !currentDirectory) {
     return (

--- a/src/components/DropZone.tsx
+++ b/src/components/DropZone.tsx
@@ -1,22 +1,19 @@
-import React, { useEffect, useState, useRef } from "react";
-import { state } from "../state";
+import React, { useEffect, useRef, useMemo } from "react";
+import { useAtomValue } from "jotai";
+import { currentDirectoryAtom, isLoadingAtom } from "../state";
 import { handleFileDrop, selectFolder } from "../handlers/dragDrop";
 import { showNotification } from "../ui/notification";
 import { CUSTOM_DRAG_EVENTS } from "../constants";
 
 export function DropZone() {
-  const [isCollapsed, setIsCollapsed] = useState(state.currentDirectory.length > 0);
-  const [isDragOver, setIsDragOver] = useState(false);
-  const [isLoading, setIsLoading] = useState(state.isLoading);
+  const currentDirectory = useAtomValue(currentDirectoryAtom);
+  const isLoading = useAtomValue(isLoadingAtom);
+  const [isDragOver, setIsDragOver] = React.useState(false);
   const fileInputRef = useRef<HTMLInputElement>(null);
+  
+  const isCollapsed = useMemo(() => currentDirectory.length > 0, [currentDirectory]);
 
   useEffect(() => {
-    // Subscribe to state changes
-    const unsubscribe = state.subscribe(() => {
-      const hasDirectory = state.currentDirectory.length > 0;
-      setIsCollapsed(hasDirectory);
-      setIsLoading(state.isLoading);
-    });
 
     // Listen to Tauri drag events for visual feedback
     const handleTauriDragEnter = () => setIsDragOver(true);
@@ -28,7 +25,6 @@ export function DropZone() {
     window.addEventListener(CUSTOM_DRAG_EVENTS.DROP, handleTauriDragLeave);
 
     return () => {
-      unsubscribe();
       window.removeEventListener(CUSTOM_DRAG_EVENTS.ENTER, handleTauriDragEnter);
       window.removeEventListener(CUSTOM_DRAG_EVENTS.OVER, handleTauriDragEnter);
       window.removeEventListener(CUSTOM_DRAG_EVENTS.LEAVE, handleTauriDragLeave);

--- a/src/components/ErrorMessage.tsx
+++ b/src/components/ErrorMessage.tsx
@@ -1,17 +1,9 @@
-import React, { useEffect, useState } from "react";
-import { state } from "../state";
+import React from "react";
+import { useAtomValue } from "jotai";
+import { errorMessageAtom } from "../state";
 
 export function ErrorMessage() {
-  const [errorText, setErrorText] = useState(state.errorMessage);
-
-  useEffect(() => {
-    // Subscribe to state changes
-    const unsubscribe = state.subscribe(() => {
-      setErrorText(state.errorMessage);
-    });
-
-    return unsubscribe;
-  }, []);
+  const errorText = useAtomValue(errorMessageAtom);
 
   if (!errorText) {
     return null;

--- a/src/components/HotkeyDialog.tsx
+++ b/src/components/HotkeyDialog.tsx
@@ -188,27 +188,29 @@ export function HotkeyDialog() {
     const selectedAction = actionSelectRef.current?.value || `action_${Date.now()}`;
     
     if (editingHotkey) {
-      // Update existing hotkey
-      const updatedHotkeys = [...hotkeys];
-      const index = updatedHotkeys.findIndex(h => h.id === editingHotkey.id);
-      if (index >= 0) {
-        updatedHotkeys[index] = {
-          ...editingHotkey,
-          key: capturedKey,
-          modifiers: [...capturedModifiers],
-          action: selectedAction
-        };
-        setHotkeys(updatedHotkeys);
-      }
+      // Update existing hotkey using functional update to avoid stale snapshots
+      setHotkeys((prev) => {
+        const copy = [...prev];
+        const index = copy.findIndex(h => h.id === editingHotkey.id);
+        if (index >= 0) {
+          copy[index] = {
+            ...editingHotkey,
+            key: capturedKey,
+            modifiers: [...capturedModifiers],
+            action: selectedAction
+          };
+        }
+        return copy;
+      });
     } else {
-      // Add new hotkey
+      // Add new hotkey using functional update to avoid stale snapshots
       const newHotkey: HotkeyConfig = {
         id: `hotkey_${Date.now()}`,
         key: capturedKey,
         modifiers: [...capturedModifiers],
         action: selectedAction
       };
-      setHotkeys([...hotkeys, newHotkey]);
+      setHotkeys((prev) => [...prev, newHotkey]);
     }
     
     try {

--- a/src/components/HotkeyList.tsx
+++ b/src/components/HotkeyList.tsx
@@ -1,6 +1,6 @@
-import React, { useEffect, useRef, useState } from "react";
-import isEqual from "fast-deep-equal";
-import { state } from "../state";
+import React from "react";
+import { useAtomValue } from "jotai";
+import { hotkeysAtom } from "../state";
 import type { HotkeyConfig } from "../types";
 
 // Format a hotkey combination for display
@@ -10,29 +10,7 @@ function formatHotkeyDisplay(config: HotkeyConfig): string {
 }
 
 export function HotkeyList() {
-  const [hotkeys, setHotkeys] = useState<HotkeyConfig[]>([]);
-  const hotkeysRef = useRef<HotkeyConfig[]>([]);
-
-  useEffect(() => {
-    // Initialize with current state before subscribing
-    const currentHotkeys = Array.isArray(state.hotkeys) ? state.hotkeys : [];
-    hotkeysRef.current = [...currentHotkeys];
-    setHotkeys([...currentHotkeys]);
-
-    // Subscribe to state changes
-    const unsubscribe = state.subscribe(() => {
-      const currentHotkeys = Array.isArray(state.hotkeys) ? state.hotkeys : [];
-      const prevHotkeys = hotkeysRef.current;
-
-      // Deep equality check using fast-deep-equal for reliable comparison
-      if (!isEqual(currentHotkeys, prevHotkeys)) {
-        hotkeysRef.current = [...currentHotkeys];
-        setHotkeys([...currentHotkeys]);
-      }
-    });
-
-    return unsubscribe;
-  }, []);
+  const hotkeys = useAtomValue(hotkeysAtom);
 
   const handleEdit = async (hotkeyId: string) => {
     const { editHotkey } = await import("../ui/hotkeys");

--- a/src/components/HotkeySidebar.tsx
+++ b/src/components/HotkeySidebar.tsx
@@ -1,5 +1,6 @@
-import React, { useEffect, useState } from "react";
-import { state } from "../state";
+import React, { useState } from "react";
+import { useAtomValue } from "jotai";
+import { isHotkeySidebarOpenAtom, currentDirectoryAtom } from "../state";
 import { toggleHotkeySidebar, closeHotkeySidebar } from "../ui/hotkeys";
 import { showCategoryDialog } from "../ui/categories";
 import { showHotkeyDialog } from "../ui/hotkeys";
@@ -9,22 +10,9 @@ import { HotkeyList } from "./HotkeyList";
 import { ConfigFileInput } from "./ConfigFileInput";
 
 export function HotkeySidebar() {
-  const [isOpen, setIsOpen] = useState(false);
+  const isOpen = useAtomValue(isHotkeySidebarOpenAtom);
+  const currentDirectory = useAtomValue(currentDirectoryAtom);
   const [activeTab, setActiveTab] = useState<"categories" | "hotkeys" | "file">("categories");
-  const [currentDirectory, setCurrentDirectory] = useState("");
-
-  useEffect(() => {
-    // Sync initial state
-    setIsOpen(state.isHotkeySidebarOpen);
-    setCurrentDirectory(state.currentDirectory);
-    
-    // Subscribe to future changes
-    const unsubscribe = state.subscribe(() => {
-      setIsOpen(state.isHotkeySidebarOpen);
-      setCurrentDirectory(state.currentDirectory);
-    });
-    return unsubscribe;
-  }, []);
 
   const handleToggle = () => {
     toggleHotkeySidebar();

--- a/src/components/ImageGridStats.tsx
+++ b/src/components/ImageGridStats.tsx
@@ -1,36 +1,26 @@
-import React, { useEffect, useState } from "react";
-import { state } from "../state";
+import React, { useMemo } from "react";
+import { useAtomValue } from "jotai";
+import { allImagePathsAtom, imageCategoriesAtom } from "../state";
 
 export function ImageGridStats() {
-  const [totalImages, setTotalImages] = useState(0);
-  const [imagesWithCategory, setImagesWithCategory] = useState(0);
-
-  useEffect(() => {
-    const updateStats = () => {
-      const images = Array.isArray(state.allImagePaths) ? state.allImagePaths : [];
-      const total = images.length;
-      
-      // Count images with at least one category
-            let withCategory = 0;
-            images.forEach((imagePathObj) => {
-              const assignments = state.imageCategories?.get(imagePathObj.path);
-              if (assignments && assignments.length > 0) {
-                withCategory++;
-              }
-            });
-      
-      setTotalImages(total);
-      setImagesWithCategory(withCategory);
-    };
-
-    // Initial update
-    updateStats();
-
-    // Subscribe to state changes
-    const unsubscribe = state.subscribe(updateStats);
-
-    return unsubscribe;
-  }, []);
+  const allImagePaths = useAtomValue(allImagePathsAtom);
+  const imageCategories = useAtomValue(imageCategoriesAtom);
+  
+  const { totalImages, imagesWithCategory } = useMemo(() => {
+    const images = Array.isArray(allImagePaths) ? allImagePaths : [];
+    const total = images.length;
+    
+    // Count images with at least one category
+    let withCategory = 0;
+    images.forEach((imagePathObj) => {
+      const assignments = imageCategories?.get(imagePathObj.path);
+      if (assignments && assignments.length > 0) {
+        withCategory++;
+      }
+    });
+    
+    return { totalImages: total, imagesWithCategory: withCategory };
+  }, [allImagePaths, imageCategories]);
 
   if (totalImages === 0) {
     return null;

--- a/src/components/Logo.tsx
+++ b/src/components/Logo.tsx
@@ -1,9 +1,12 @@
 import React from "react";
-import { state } from "../state";
+import { useSetAtom } from "jotai";
+import { resetStateAtom } from "../state";
 
 export function Logo() {
+  const resetState = useSetAtom(resetStateAtom);
+  
   const handleClick = () => {
-    state.reset();
+    resetState();
   };
 
   return (

--- a/src/components/ModalCategories.tsx
+++ b/src/components/ModalCategories.tsx
@@ -1,5 +1,6 @@
-import React, { useEffect, useState } from "react";
-import { state } from "../state";
+import React from "react";
+import { useAtomValue } from "jotai";
+import { currentModalImagePathAtom, categoriesAtom, imageCategoriesAtom } from "../state";
 import type { Category, CategoryAssignment } from "../types";
 
 function getContrastColor(hexColor: string): string {
@@ -42,28 +43,9 @@ function getContrastColor(hexColor: string): string {
 }
 
 export function ModalCategories() {
-  const [categories, setCategories] = useState<Category[]>([]);
-  const [imageCategories, setImageCategories] = useState<Map<string, CategoryAssignment[]>>(new Map());
-  const [currentImagePath, setCurrentImagePath] = useState<string>("");
-
-  // Subscribe to state changes
-  useEffect(() => {
-    // One-time initial sync
-    const modalImagePath = state.currentModalImagePath;
-    setCurrentImagePath(modalImagePath || "");
-    setCategories([...state.categories]);
-    setImageCategories(new Map(state.imageCategories));
-    
-    // Subscribe to state changes
-    const unsubscribe = state.subscribe(() => {
-      const newModalImagePath = state.currentModalImagePath;
-      setCurrentImagePath(newModalImagePath || "");
-      setCategories([...state.categories]);
-      setImageCategories(new Map(state.imageCategories));
-    });
-    
-    return unsubscribe;
-  }, []);
+  const currentImagePath = useAtomValue(currentModalImagePathAtom);
+  const categories = useAtomValue(categoriesAtom);
+  const imageCategories = useAtomValue(imageCategoriesAtom);
 
   // Don't render if modal is not open or no categories assigned
   if (!currentImagePath) {

--- a/src/components/ModalCategories.tsx
+++ b/src/components/ModalCategories.tsx
@@ -2,45 +2,7 @@ import React from "react";
 import { useAtomValue } from "jotai";
 import { currentModalImagePathAtom, categoriesAtom, imageCategoriesAtom } from "../state";
 import type { Category, CategoryAssignment } from "../types";
-
-function getContrastColor(hexColor: string): string {
-  // Remove # if present
-  const hex = hexColor.replace("#", "");
-
-  // Validate hex format
-  if (!/^[0-9A-Fa-f]{6}$/.test(hex)) {
-    console.warn(`Invalid hex color: ${hexColor}`);
-    return "#000000"; // Default to black
-  }
-
-  // Convert to RGB (0-255)
-  const r = parseInt(hex.substring(0, 2), 16);
-  const g = parseInt(hex.substring(2, 4), 16);
-  const b = parseInt(hex.substring(4, 6), 16);
-
-  // Calculate relative luminance with gamma correction (WCAG 2.0 formula)
-  const getRelativeLuminance = (value: number): number => {
-    const normalized = value / 255;
-    return normalized <= 0.03928
-      ? normalized / 12.92
-      : Math.pow((normalized + 0.055) / 1.055, 2.4);
-  };
-
-  const l1 = 0.2126 * getRelativeLuminance(r) + 
-             0.7152 * getRelativeLuminance(g) + 
-             0.0722 * getRelativeLuminance(b);
-
-  // Relative luminances for black and white
-  const blackLuminance = 0; // #000000
-  const whiteLuminance = 1; // #ffffff
-
-  // Calculate contrast ratios (WCAG formula: (L1 + 0.05) / (L2 + 0.05))
-  const contrastWithBlack = (l1 + 0.05) / (blackLuminance + 0.05);
-  const contrastWithWhite = (whiteLuminance + 0.05) / (l1 + 0.05);
-
-  // Return the color with better contrast ratio
-  return contrastWithBlack > contrastWithWhite ? "#000000" : "#ffffff";
-}
+import { getContrastColor } from "../utils/colors";
 
 export function ModalCategories() {
   const currentImagePath = useAtomValue(currentModalImagePathAtom);

--- a/src/components/ShortcutsOverlay.tsx
+++ b/src/components/ShortcutsOverlay.tsx
@@ -1,36 +1,7 @@
 import React from "react";
 import { useAtomValue } from "jotai";
 import { shortcutsOverlayVisibleAtom, hotkeysAtom, categoriesAtom } from "../state";
-import type { HotkeyConfig, Category } from "../types";
 import { hideShortcutsOverlay } from "../ui/modal";
-
-// Deep equality check for HotkeyConfig arrays
-function hotkeysEqual(a: HotkeyConfig[], b: HotkeyConfig[]): boolean {
-  if (a.length !== b.length) return false;
-  return a.every((hotkey, i) => {
-    const other = b[i];
-    return (
-      hotkey.id === other.id &&
-      hotkey.key === other.key &&
-      hotkey.action === other.action &&
-      hotkey.modifiers.length === other.modifiers.length &&
-      hotkey.modifiers.every((mod, j) => mod === other.modifiers[j])
-    );
-  });
-}
-
-// Deep equality check for Category arrays
-function categoriesEqual(a: Category[], b: Category[]): boolean {
-  if (a.length !== b.length) return false;
-  return a.every((category, i) => {
-    const other = b[i];
-    return (
-      category.id === other.id &&
-      category.name === other.name &&
-      category.color === other.color
-    );
-  });
-}
 
 export function ShortcutsOverlay() {
   const isVisible = useAtomValue(shortcutsOverlayVisibleAtom);

--- a/src/components/ShortcutsOverlay.tsx
+++ b/src/components/ShortcutsOverlay.tsx
@@ -1,5 +1,6 @@
-import React, { useEffect, useState, useRef } from "react";
-import { state } from "../state";
+import React from "react";
+import { useAtomValue } from "jotai";
+import { shortcutsOverlayVisibleAtom, hotkeysAtom, categoriesAtom } from "../state";
 import type { HotkeyConfig, Category } from "../types";
 import { hideShortcutsOverlay } from "../ui/modal";
 
@@ -32,50 +33,9 @@ function categoriesEqual(a: Category[], b: Category[]): boolean {
 }
 
 export function ShortcutsOverlay() {
-  const [isVisible, setIsVisible] = useState(false);
-  const [hotkeys, setHotkeys] = useState<HotkeyConfig[]>([]);
-  const [categories, setCategories] = useState<Category[]>([]);
-  
-  // Use refs to track previous values for deep equality checks
-  const prevIsVisibleRef = useRef<boolean>(false);
-  const prevHotkeysRef = useRef<HotkeyConfig[]>([]);
-  const prevCategoriesRef = useRef<Category[]>([]);
-
-  // Subscribe to state changes instead of polling
-  useEffect(() => {
-    // Initialize state
-    setIsVisible(state.shortcutsOverlayVisible);
-    setHotkeys([...state.hotkeys]);
-    setCategories([...state.categories]);
-    prevIsVisibleRef.current = state.shortcutsOverlayVisible;
-    prevHotkeysRef.current = [...state.hotkeys];
-    prevCategoriesRef.current = [...state.categories];
-    
-    // Subscribe to state changes
-    const unsubscribe = state.subscribe(() => {
-      // Update visibility only if it actually changed
-      if (state.shortcutsOverlayVisible !== prevIsVisibleRef.current) {
-        setIsVisible(state.shortcutsOverlayVisible);
-        prevIsVisibleRef.current = state.shortcutsOverlayVisible;
-      }
-      
-      // Update hotkeys only if content actually differs
-      if (!hotkeysEqual(state.hotkeys, prevHotkeysRef.current)) {
-        const newHotkeys = [...state.hotkeys];
-        setHotkeys(newHotkeys);
-        prevHotkeysRef.current = newHotkeys;
-      }
-      
-      // Update categories only if content actually differs
-      if (!categoriesEqual(state.categories, prevCategoriesRef.current)) {
-        const newCategories = [...state.categories];
-        setCategories(newCategories);
-        prevCategoriesRef.current = newCategories;
-      }
-    });
-    
-    return unsubscribe;
-  }, []);
+  const isVisible = useAtomValue(shortcutsOverlayVisibleAtom);
+  const hotkeys = useAtomValue(hotkeysAtom);
+  const categories = useAtomValue(categoriesAtom);
 
   if (!isVisible) {
     return null;

--- a/src/core/browse.test.ts
+++ b/src/core/browse.test.ts
@@ -6,7 +6,6 @@ import {
   currentIndexAtom,
   isLoadingBatchAtom,
   loadedImagesAtom,
-  currentModalIndexAtom,
   currentModalImagePathAtom,
   currentDirectoryAtom,
   configFilePathAtom,
@@ -95,7 +94,7 @@ describe("browse", () => {
       // Set invalid value - ensureImagePathsArray will handle this
       store.set(allImagePathsAtom, null as any);
 
-      await loadImageBatch(0, 10);
+      await loadImageBatch(0);
 
       expect(consoleSpy).toHaveBeenCalled();
       expect(store.get(allImagePathsAtom)).toEqual([]);
@@ -106,7 +105,7 @@ describe("browse", () => {
       const consoleSpy = vi.spyOn(console, "error").mockImplementation(() => {});
       store.set(allImagePathsAtom, "not an array" as any);
 
-      await loadImageBatch(0, 10);
+      await loadImageBatch(0);
 
       expect(consoleSpy).toHaveBeenCalled();
       expect(store.get(allImagePathsAtom)).toEqual([]);
@@ -117,7 +116,7 @@ describe("browse", () => {
       store.set(allImagePathsAtom, [{ path: "/test/image1.png" }]);
       store.set(isLoadingBatchAtom, true);
 
-      await loadImageBatch(0, 10);
+      await loadImageBatch(0);
 
       // We just verify it doesn't throw and resets loading state
       expect(store.get(isLoadingBatchAtom)).toBe(true); // Still true since it returns early
@@ -126,7 +125,7 @@ describe("browse", () => {
     it("should return early if startIndex >= allImagePaths.length", async () => {
       store.set(allImagePathsAtom, [{ path: "/test/image1.png" }]);
 
-      await loadImageBatch(10, 20);
+      await loadImageBatch(10);
 
       expect(store.get(isLoadingBatchAtom)).toBe(false);
     });
@@ -135,7 +134,7 @@ describe("browse", () => {
       // This test verifies it doesn't throw
       store.set(allImagePathsAtom, [{ path: "/test/image1.png" }]);
 
-      await loadImageBatch(0, 10);
+      await loadImageBatch(0);
 
       expect(store.get(isLoadingBatchAtom)).toBe(false);
     });
@@ -147,7 +146,7 @@ describe("browse", () => {
         { path: "/test/image2.png" },
       ]);
 
-      await loadImageBatch(0, 2);
+      await loadImageBatch(0);
 
       // Function is no-op, React component handles rendering
       expect(store.get(isLoadingBatchAtom)).toBe(false);
@@ -157,17 +156,17 @@ describe("browse", () => {
       // This test verifies the function completes without errors
       store.set(allImagePathsAtom, [{ path: "/test/image1.png" }]);
 
-      await loadImageBatch(0, 1);
+      await loadImageBatch(0);
 
       // Function is no-op, React component handles error states
       expect(store.get(isLoadingBatchAtom)).toBe(false);
     });
 
-    it("should clamp endIndex to array length", async () => {
-      // This test verifies the function completes correctly
+    it("should handle out-of-range startIndex", async () => {
+      // This test verifies the function completes correctly for out-of-range indices
       store.set(allImagePathsAtom, [{ path: "/test/image1.png" }]);
 
-      await loadImageBatch(0, 100);
+      await loadImageBatch(100);
 
       // Function is no-op, React component handles rendering
       expect(store.get(isLoadingBatchAtom)).toBe(false);
@@ -257,7 +256,6 @@ describe("browse", () => {
     it("should reset state before browsing", async () => {
       store.set(currentIndexAtom, 100);
       store.set(isLoadingBatchAtom, true);
-      store.set(currentModalIndexAtom, 5);
       vi.mocked(invokeTauri).mockResolvedValueOnce({
         directories: [],
         images: [],
@@ -267,7 +265,6 @@ describe("browse", () => {
 
       expect(store.get(currentIndexAtom)).toBe(0); // Reset to 0 when empty
       expect(store.get(isLoadingBatchAtom)).toBe(false);
-      expect(store.get(currentModalIndexAtom)).toBe(-1);
     });
 
     it("should show notification when no images or directories found", async () => {

--- a/src/core/browse.test.ts
+++ b/src/core/browse.test.ts
@@ -278,6 +278,21 @@ describe("browse", () => {
       expect(showNotification).toHaveBeenCalledWith(
         "No images or directories found in this directory."
       );
+      // Should set currentIndexAtom to 0 when images.length === 0 (line 101)
+      expect(store.get(currentIndexAtom)).toBe(0);
+    });
+
+    it("should set currentIndexAtom to 0 when images array is empty (branch: images.length === 0)", async () => {
+      vi.mocked(invokeTauri).mockResolvedValueOnce({
+        directories: ["/test/subdir"],
+        images: [], // Empty images array
+      });
+
+      await browseImages("/test/path");
+
+      // When images.length === 0, currentIndexAtom should be set to 0 (line 101)
+      expect(store.get(currentIndexAtom)).toBe(0);
+      expect(store.get(allDirectoryPathsAtom)).toEqual(["/test/subdir"]);
     });
   });
 });

--- a/src/core/browse.ts
+++ b/src/core/browse.ts
@@ -5,7 +5,6 @@ import {
   currentIndexAtom,
   isLoadingBatchAtom,
   loadedImagesAtom,
-  currentModalIndexAtom,
   currentModalImagePathAtom,
   currentDirectoryAtom,
   configFilePathAtom,
@@ -34,9 +33,8 @@ import { invokeTauri, isTauriInvokeAvailable } from "../utils/tauri";
  * but it should be understood that this is a state management function, not an image loading function.
  * 
  * @param startIndex - Start index of the batch; used to guard against out-of-range requests
- * @param endIndex - End index of the batch (unused, kept for API compatibility)
  */
-export async function loadImageBatch(startIndex: number, endIndex: number): Promise<void> {
+export async function loadImageBatch(startIndex: number): Promise<void> {
   if (!ensureImagePathsArray("loadImageBatch")) {
     return;
   }
@@ -67,7 +65,6 @@ export async function browseImages(path: string): Promise<void> {
   store.set(currentIndexAtom, 0);
   store.set(isLoadingBatchAtom, false);
   store.set(loadedImagesAtom, new Map<string, string>());
-  store.set(currentModalIndexAtom, -1);
   store.set(currentModalImagePathAtom, "");
   store.set(currentDirectoryAtom, path);
   

--- a/src/handlers/dragDrop.test.ts
+++ b/src/handlers/dragDrop.test.ts
@@ -10,7 +10,8 @@ import {
   selectFolder,
 } from './dragDrop';
 import { DRAG_EVENTS, CUSTOM_DRAG_EVENTS } from '../constants';
-import { state } from '../state';
+import { store } from '../utils/jotaiStore';
+import { isLoadingAtom } from '../state';
 
 // Mock dependencies
 vi.mock('../core/browse', () => ({
@@ -90,6 +91,72 @@ describe('extractPathsFromEvent', () => {
   it('should handle single path in array', () => {
     expect(extractPathsFromEvent(['/single/path'])).toEqual(['/single/path']);
   });
+
+  it('should handle event with payload.paths as empty array', () => {
+    const event: Event<DragDropEvent> = {
+      event: 'test-event',
+      id: 1,
+      payload: {
+        paths: [],
+      },
+    } as Event<DragDropEvent>;
+    expect(extractPathsFromEvent(event)).toEqual([]);
+  });
+
+  it('should handle event with payload as empty array', () => {
+    const event: Event<DragDropEvent> = {
+      payload: [] as any,
+    } as Event<DragDropEvent>;
+    expect(extractPathsFromEvent(event)).toEqual([]);
+  });
+
+  it('should handle DragDropEvent with empty paths array', () => {
+    const event: DragDropEvent = {
+      paths: [],
+    };
+    expect(extractPathsFromEvent(event)).toEqual([]);
+  });
+
+  it('should return null for event with payload but no paths property', () => {
+    const event: Event<DragDropEvent> = {
+      payload: {
+        otherProperty: 'value',
+      } as any,
+    } as Event<DragDropEvent>;
+    expect(extractPathsFromEvent(event)).toBeNull();
+  });
+
+  it('should return null for event with paths property but not an array', () => {
+    const event = {
+      paths: 'not-an-array',
+    } as any;
+    expect(extractPathsFromEvent(event)).toBeNull();
+  });
+
+  it('should handle event with payload.paths containing special characters', () => {
+    const paths = ['/path/with spaces/file.jpg', '/path/with-special@chars#file.png'];
+    const event: Event<DragDropEvent> = {
+      payload: {
+        paths,
+      },
+    } as Event<DragDropEvent>;
+    expect(extractPathsFromEvent(event)).toEqual(paths);
+  });
+
+  it('should handle Windows-style paths', () => {
+    const paths = ['C:\\Users\\test\\file.jpg', 'D:\\Images\\photo.png'];
+    const event: Event<DragDropEvent> = {
+      payload: {
+        paths,
+      },
+    } as Event<DragDropEvent>;
+    expect(extractPathsFromEvent(event)).toEqual(paths);
+  });
+
+  it('should handle very long path arrays', () => {
+    const paths = Array.from({ length: 1000 }, (_, i) => `/path/to/file${i}.jpg`);
+    expect(extractPathsFromEvent(paths)).toEqual(paths);
+  });
 });
 
 describe('handleFolder', () => {
@@ -105,7 +172,7 @@ describe('handleFolder', () => {
 describe('handleFileDrop', () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    state.isLoading = false;
+    store.set(isLoadingAtom, false);
   });
 
   it('should clear error and handle successful folder drop', async () => {
@@ -127,7 +194,7 @@ describe('handleFileDrop', () => {
     await handleFileDrop(null as any);
 
     expect(clearError).toHaveBeenCalled();
-    expect(state.isLoading).toBe(false);
+      expect(store.get(isLoadingAtom)).toBe(false);
     expect(showError).toHaveBeenCalledWith('No file paths detected in drop event.');
   });
 
@@ -138,7 +205,7 @@ describe('handleFileDrop', () => {
 
     await handleFileDrop(['/test/path']);
 
-    expect(state.isLoading).toBe(false);
+      expect(store.get(isLoadingAtom)).toBe(false);
     expect(showError).toHaveBeenCalledWith('Tauri invoke API not available');
   });
 
@@ -167,7 +234,7 @@ describe('handleFileDrop', () => {
 
     await handleFileDrop(['/test/file.png']);
 
-    expect(state.isLoading).toBe(false);
+      expect(store.get(isLoadingAtom)).toBe(false);
     expect(showError).toHaveBeenCalledWith('Error: Error: Parent not found. Please drop a folder or use the file picker.');
   });
 
@@ -185,6 +252,93 @@ describe('handleFileDrop', () => {
     await handleFileDrop(event);
 
     expect(browseImages).toHaveBeenCalledWith('/test/folder');
+  });
+
+  it('should handle empty paths array', async () => {
+    const { showError, clearError } = await import('../ui/error');
+
+    await handleFileDrop([]);
+
+    expect(clearError).toHaveBeenCalled();
+    expect(store.get(isLoadingAtom)).toBe(false);
+    expect(showError).toHaveBeenCalledWith('No file paths detected in drop event.');
+  });
+
+  it('should use first path when multiple paths are provided', async () => {
+    const { invokeTauri } = await import('../utils/tauri');
+    const { browseImages } = await import('../core/browse');
+    vi.mocked(invokeTauri).mockResolvedValueOnce({ images: [], directories: [] });
+
+    await handleFileDrop(['/first/path', '/second/path', '/third/path']);
+
+    expect(invokeTauri).toHaveBeenCalledWith('list_images', { path: '/first/path' });
+    expect(browseImages).toHaveBeenCalledWith('/first/path');
+  });
+
+  it('should handle DragDropEvent format directly', async () => {
+    const { invokeTauri } = await import('../utils/tauri');
+    const { browseImages } = await import('../core/browse');
+    vi.mocked(invokeTauri).mockResolvedValueOnce({ images: [], directories: [] });
+
+    const event: DragDropEvent = {
+      paths: ['/test/folder'],
+    };
+
+    await handleFileDrop(event);
+
+    expect(browseImages).toHaveBeenCalledWith('/test/folder');
+  });
+
+  it('should handle parent directory fallback with Windows paths', async () => {
+    const { invokeTauri } = await import('../utils/tauri');
+    const { browseImages } = await import('../core/browse');
+    
+    vi.mocked(invokeTauri)
+      .mockRejectedValueOnce(new Error('Not a directory'))
+      .mockResolvedValueOnce('C:\\Users\\test');
+
+    await handleFileDrop(['C:\\Users\\test\\file.png']);
+
+    expect(invokeTauri).toHaveBeenCalledWith('list_images', { path: 'C:\\Users\\test\\file.png' });
+    expect(invokeTauri).toHaveBeenCalledWith('get_parent_directory', { filePath: 'C:\\Users\\test\\file.png' });
+    expect(browseImages).toHaveBeenCalledWith('C:\\Users\\test');
+  });
+
+  it('should handle parent directory fallback with special characters in path', async () => {
+    const { invokeTauri } = await import('../utils/tauri');
+    const { browseImages } = await import('../core/browse');
+    
+    vi.mocked(invokeTauri)
+      .mockRejectedValueOnce(new Error('Not a directory'))
+      .mockResolvedValueOnce('/parent/path with spaces');
+
+    await handleFileDrop(['/parent/path with spaces/file@name#.png']);
+
+    expect(browseImages).toHaveBeenCalledWith('/parent/path with spaces');
+  });
+
+  it('should clear error before processing', async () => {
+    const { clearError } = await import('../ui/error');
+    const { invokeTauri } = await import('../utils/tauri');
+    vi.mocked(invokeTauri).mockResolvedValueOnce({ images: [], directories: [] });
+
+    await handleFileDrop(['/test/folder']);
+
+    expect(clearError).toHaveBeenCalled();
+  });
+
+  it('should handle error when parent directory returns empty string', async () => {
+    const { invokeTauri } = await import('../utils/tauri');
+    const { showError } = await import('../ui/error');
+    
+    vi.mocked(invokeTauri)
+      .mockRejectedValueOnce(new Error('Not a directory'))
+      .mockResolvedValueOnce(''); // Empty parent path
+
+    await handleFileDrop(['/test/file.png']);
+
+    // Should still try to browse with empty path (browseImages will handle it)
+    expect(invokeTauri).toHaveBeenCalledTimes(2);
   });
 });
 
@@ -259,12 +413,79 @@ describe('setupDocumentDragHandlers', () => {
 
     expect(preventDefaultSpy).not.toHaveBeenCalled();
   });
+
+  it('should handle missing drop zone gracefully', () => {
+    // No drop zone in DOM
+    const cleanup = setupDocumentDragHandlers();
+
+    const dragoverEvent = document.createEvent('Event');
+    dragoverEvent.initEvent('dragover', true, true);
+    const preventDefaultSpy = vi.spyOn(dragoverEvent, 'preventDefault');
+
+    document.dispatchEvent(dragoverEvent);
+
+    // Should preventDefault when drop zone doesn't exist
+    expect(preventDefaultSpy).toHaveBeenCalled();
+    
+    cleanup();
+  });
+
+  it('should handle event target being null', () => {
+    const dropZone = document.createElement('div');
+    dropZone.id = 'drop-zone';
+    document.body.appendChild(dropZone);
+
+    setupDocumentDragHandlers();
+
+    const dragoverEvent = document.createEvent('Event');
+    dragoverEvent.initEvent('dragover', true, true);
+    Object.defineProperty(dragoverEvent, 'target', { value: null, writable: false });
+    
+    const preventDefaultSpy = vi.spyOn(dragoverEvent, 'preventDefault');
+
+    document.dispatchEvent(dragoverEvent);
+
+    // Should preventDefault when target is null
+    expect(preventDefaultSpy).toHaveBeenCalled();
+  });
+
+  it('should handle multiple cleanup calls', () => {
+    const cleanup = setupDocumentDragHandlers();
+    
+    // Call cleanup multiple times
+    cleanup();
+    cleanup();
+    cleanup();
+
+    // Should not throw
+    expect(() => cleanup()).not.toThrow();
+  });
+
+  it('should handle drop zone being removed after setup', () => {
+    const dropZone = document.createElement('div');
+    dropZone.id = 'drop-zone';
+    document.body.appendChild(dropZone);
+
+    setupDocumentDragHandlers();
+
+    // Remove drop zone
+    dropZone.remove();
+
+    const dragoverEvent = document.createEvent('Event');
+    dragoverEvent.initEvent('dragover', true, true);
+    const preventDefaultSpy = vi.spyOn(dragoverEvent, 'preventDefault');
+
+    document.dispatchEvent(dragoverEvent);
+
+    // Should preventDefault when drop zone is removed
+    expect(preventDefaultSpy).toHaveBeenCalled();
+  });
 });
 
 describe('setupTauriDragEvents', () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    state.isLoading = false;
+    store.set(isLoadingAtom, false);
     (window as any).__TAURI__ = {
       event: {
         listen: vi.fn().mockResolvedValue(() => {}),
@@ -274,7 +495,7 @@ describe('setupTauriDragEvents', () => {
 
   afterEach(() => {
     delete (window as any).__TAURI__;
-    state.isLoading = false;
+    store.set(isLoadingAtom, false);
   });
 
   it('should return early when Tauri event API is not available', async () => {
@@ -417,7 +638,7 @@ describe('setupTauriDragEvents', () => {
       await new Promise((resolve) => setTimeout(resolve, 0));
     }
 
-    expect(state.isLoading).toBe(true);
+      expect(store.get(isLoadingAtom)).toBe(true);
     expect(clearError).toHaveBeenCalled();
     expect(customEventSpy).toHaveBeenCalledWith(expect.objectContaining({ type: CUSTOM_DRAG_EVENTS.DROP }));
   });
@@ -483,7 +704,7 @@ describe('setupTauriDragEvents', () => {
   });
 
   it('should handle LEAVE event correctly', async () => {
-    state.isLoading = true; // Set loading state first
+    store.set(isLoadingAtom, true); // Set loading state first
     let leaveHandler: ((event: Event<DragDropEvent>) => void) | null = null;
 
     const eventListen = vi.fn().mockImplementation((eventName, handler: (event: Event<DragDropEvent>) => void) => {
@@ -510,7 +731,7 @@ describe('setupTauriDragEvents', () => {
       (leaveHandler as (event: Event<DragDropEvent>) => void)(event);
     }
 
-    expect(state.isLoading).toBe(false);
+      expect(store.get(isLoadingAtom)).toBe(false);
     expect(customEventSpy).toHaveBeenCalledWith(expect.objectContaining({ type: CUSTOM_DRAG_EVENTS.LEAVE }));
   });
 
@@ -555,8 +776,8 @@ describe('setupTauriDragEvents', () => {
     }
 
     // Verify error handling occurred - the .catch() in setupTauriDragEvents should have run
-    // Check that state.isLoading was set to false and showError was called (the important side effects)
-    expect(state.isLoading).toBe(false);
+    // Check that isLoadingAtom was set to false and showError was called (the important side effects)
+    expect(store.get(isLoadingAtom)).toBe(false);
     expect(showError).toHaveBeenCalledWith(expect.stringContaining('Error'));
     // console.error may or may not be called depending on timing, but the UI updates are what matter
     consoleSpy.mockRestore();
@@ -632,12 +853,219 @@ describe('setupTauriDragEvents', () => {
     expect(typeof cleanup).toBe('function');
     consoleSpy.mockRestore();
   });
+
+  it('should handle event.listen returning undefined unlisten function', async () => {
+    const eventListen = vi.fn().mockResolvedValue(undefined);
+    (window as any).__TAURI__ = {
+      event: {
+        listen: eventListen,
+      },
+    };
+
+    const cleanup = await setupTauriDragEvents();
+
+    expect(cleanup).toBeDefined();
+    if (cleanup) {
+      // Should not throw even if unlisten is undefined
+      expect(() => cleanup()).not.toThrow();
+    }
+  });
+
+  it('should handle all event registrations failing', async () => {
+    const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const eventListen = vi.fn().mockRejectedValue(new Error('Registration failed'));
+    (window as any).__TAURI__ = {
+      event: {
+        listen: eventListen,
+      },
+    };
+
+    const cleanup = await setupTauriDragEvents();
+
+    expect(eventListen).toHaveBeenCalledTimes(4);
+    expect(consoleSpy).toHaveBeenCalled();
+    // Should still return cleanup function (even if empty)
+    expect(cleanup).toBeDefined();
+    expect(typeof cleanup).toBe('function');
+    if (cleanup) {
+      // Cleanup should not throw even with no listeners
+      expect(() => cleanup()).not.toThrow();
+    }
+    consoleSpy.mockRestore();
+  });
+
+  it('should handle DROP event with empty paths', async () => {
+    const { showError } = await import('../ui/error');
+    let dropHandler: ((event: Event<DragDropEvent>) => void) | null = null;
+
+    const eventListen = vi.fn().mockImplementation((eventName, handler: (event: Event<DragDropEvent>) => void) => {
+      if (eventName === DRAG_EVENTS.DROP) {
+        dropHandler = handler;
+      }
+      return Promise.resolve(() => {});
+    });
+
+    (window as any).__TAURI__ = {
+      event: {
+        listen: eventListen,
+      },
+    };
+
+    await setupTauriDragEvents();
+
+    const event: Event<DragDropEvent> = {
+      event: 'test-event',
+      id: 1,
+      payload: { paths: [] },
+    } as Event<DragDropEvent>;
+
+    if (dropHandler) {
+      (dropHandler as (event: Event<DragDropEvent>) => void)(event);
+      await new Promise((resolve) => setTimeout(resolve, 50));
+    }
+
+    expect(store.get(isLoadingAtom)).toBe(false);
+    expect(showError).toHaveBeenCalledWith('No file paths detected in drop event.');
+  });
+
+  it('should handle DROP event with null payload', async () => {
+    const { showError } = await import('../ui/error');
+    let dropHandler: ((event: Event<DragDropEvent>) => void) | null = null;
+
+    const eventListen = vi.fn().mockImplementation((eventName, handler: (event: Event<DragDropEvent>) => void) => {
+      if (eventName === DRAG_EVENTS.DROP) {
+        dropHandler = handler;
+      }
+      return Promise.resolve(() => {});
+    });
+
+    (window as any).__TAURI__ = {
+      event: {
+        listen: eventListen,
+      },
+    };
+
+    await setupTauriDragEvents();
+
+    const event: Event<DragDropEvent> = {
+      payload: null as any,
+    } as Event<DragDropEvent>;
+
+    if (dropHandler) {
+      (dropHandler as (event: Event<DragDropEvent>) => void)(event);
+      await new Promise((resolve) => setTimeout(resolve, 50));
+    }
+
+    expect(store.get(isLoadingAtom)).toBe(false);
+    expect(showError).toHaveBeenCalledWith('No file paths detected in drop event.');
+  });
+
+  it('should handle multiple DROP events in sequence', async () => {
+    const { invokeTauri } = await import('../utils/tauri');
+    const { browseImages } = await import('../core/browse');
+    let dropHandler: ((event: Event<DragDropEvent>) => void) | null = null;
+
+    const eventListen = vi.fn().mockImplementation((eventName, handler: (event: Event<DragDropEvent>) => void) => {
+      if (eventName === DRAG_EVENTS.DROP) {
+        dropHandler = handler;
+      }
+      return Promise.resolve(() => {});
+    });
+
+    (window as any).__TAURI__ = {
+      event: {
+        listen: eventListen,
+      },
+    };
+
+    vi.mocked(invokeTauri).mockResolvedValue({ images: [], directories: [] });
+
+    await setupTauriDragEvents();
+
+    const event1: Event<DragDropEvent> = {
+      payload: { paths: ['/path1'] },
+    } as Event<DragDropEvent>;
+    const event2: Event<DragDropEvent> = {
+      payload: { paths: ['/path2'] },
+    } as Event<DragDropEvent>;
+
+    if (dropHandler) {
+      (dropHandler as (event: Event<DragDropEvent>) => void)(event1);
+      await new Promise((resolve) => setTimeout(resolve, 10));
+      (dropHandler as (event: Event<DragDropEvent>) => void)(event2);
+      await new Promise((resolve) => setTimeout(resolve, 10));
+    }
+
+    expect(browseImages).toHaveBeenCalledWith('/path1');
+    expect(browseImages).toHaveBeenCalledWith('/path2');
+  });
+
+  it('should handle cleanup being called multiple times', async () => {
+    const unlisten1 = vi.fn();
+    const unlisten2 = vi.fn();
+    const unlisten3 = vi.fn();
+    const unlisten4 = vi.fn();
+    let callCount = 0;
+    const eventListen = vi.fn().mockImplementation(() => {
+      callCount++;
+      if (callCount === 1) return Promise.resolve(unlisten1);
+      if (callCount === 2) return Promise.resolve(unlisten2);
+      if (callCount === 3) return Promise.resolve(unlisten3);
+      if (callCount === 4) return Promise.resolve(unlisten4);
+      return Promise.resolve(() => {});
+    });
+    (window as any).__TAURI__ = {
+      event: {
+        listen: eventListen,
+      },
+    };
+
+    const cleanup = await setupTauriDragEvents();
+
+    if (cleanup) {
+      cleanup();
+      cleanup();
+      cleanup();
+    }
+
+    // Each unlisten is called once per cleanup call
+    expect(unlisten1).toHaveBeenCalledTimes(3);
+    expect(unlisten2).toHaveBeenCalledTimes(3);
+    expect(unlisten3).toHaveBeenCalledTimes(3);
+    expect(unlisten4).toHaveBeenCalledTimes(3);
+  });
+
+  it('should handle window.__TAURI__ being undefined after setup', async () => {
+    const unlisten1 = vi.fn();
+    let callCount = 0;
+    const eventListen = vi.fn().mockImplementation(() => {
+      callCount++;
+      if (callCount === 1) return Promise.resolve(unlisten1);
+      return Promise.resolve(() => {});
+    });
+    (window as any).__TAURI__ = {
+      event: {
+        listen: eventListen,
+      },
+    };
+
+    const cleanup = await setupTauriDragEvents();
+
+    // Remove Tauri after setup
+    delete (window as any).__TAURI__;
+
+    if (cleanup) {
+      // Cleanup should still work
+      expect(() => cleanup()).not.toThrow();
+      expect(unlisten1).toHaveBeenCalled();
+    }
+  });
 });
 
 describe('selectFolder', () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    state.isLoading = false;
+    store.set(isLoadingAtom, false);
   });
 
   it('should call handleFolder when folder is selected as string', async () => {
@@ -667,7 +1095,7 @@ describe('selectFolder', () => {
 
     await selectFolder();
 
-    expect(state.isLoading).toBe(false);
+      expect(store.get(isLoadingAtom)).toBe(false);
     expect(browseImages).not.toHaveBeenCalled();
   });
 
@@ -677,7 +1105,7 @@ describe('selectFolder', () => {
 
     await selectFolder();
 
-    expect(state.isLoading).toBe(false);
+      expect(store.get(isLoadingAtom)).toBe(false);
   });
 
   it('should handle errors and show error message', async () => {
@@ -687,8 +1115,122 @@ describe('selectFolder', () => {
 
     await selectFolder();
 
-    expect(state.isLoading).toBe(false);
+      expect(store.get(isLoadingAtom)).toBe(false);
     expect(showError).toHaveBeenCalledWith('Error selecting folder: Error: Dialog error');
+  });
+
+  it('should handle array with multiple folders (uses first)', async () => {
+    const { open } = await import('../utils/dialog');
+    const { browseImages } = await import('../core/browse');
+    vi.mocked(open).mockResolvedValueOnce(['/folder1', '/folder2', '/folder3']);
+
+    await selectFolder();
+
+    expect(browseImages).toHaveBeenCalledWith('/folder1');
+    expect(browseImages).toHaveBeenCalledTimes(1);
+  });
+
+  it('should handle array with empty string', async () => {
+    const { open } = await import('../utils/dialog');
+    vi.mocked(open).mockResolvedValueOnce(['']);
+
+    await selectFolder();
+
+    // Should still call handleFolder with empty string (browseImages will handle validation)
+    const { browseImages } = await import('../core/browse');
+    expect(browseImages).toHaveBeenCalledWith('');
+  });
+
+  it('should handle non-string, non-array return value', async () => {
+    const { open } = await import('../utils/dialog');
+    vi.mocked(open).mockResolvedValueOnce({ path: '/folder' } as any);
+
+    await selectFolder();
+
+    expect(store.get(isLoadingAtom)).toBe(false);
+    const { browseImages } = await import('../core/browse');
+    expect(browseImages).not.toHaveBeenCalled();
+  });
+
+  it('should handle error with string message', async () => {
+    const { open } = await import('../utils/dialog');
+    const { showError } = await import('../ui/error');
+    vi.mocked(open).mockRejectedValueOnce('String error message');
+
+    await selectFolder();
+
+    expect(store.get(isLoadingAtom)).toBe(false);
+    expect(showError).toHaveBeenCalledWith('Error selecting folder: String error message');
+  });
+
+  it('should handle error with undefined', async () => {
+    const { open } = await import('../utils/dialog');
+    const { showError } = await import('../ui/error');
+    vi.mocked(open).mockRejectedValueOnce(undefined);
+
+    await selectFolder();
+
+    expect(store.get(isLoadingAtom)).toBe(false);
+    expect(showError).toHaveBeenCalledWith('Error selecting folder: undefined');
+  });
+});
+
+describe('handleFileDrop edge cases', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    store.set(isLoadingAtom, false);
+  });
+
+  it('should handle very long path strings', async () => {
+    const { invokeTauri } = await import('../utils/tauri');
+    const { browseImages } = await import('../core/browse');
+    const longPath = '/very/long/path/' + 'a'.repeat(1000) + '/folder';
+    vi.mocked(invokeTauri).mockResolvedValueOnce({ images: [], directories: [] });
+
+    await handleFileDrop([longPath]);
+
+    expect(invokeTauri).toHaveBeenCalledWith('list_images', { path: longPath });
+    expect(browseImages).toHaveBeenCalledWith(longPath);
+  });
+
+  it('should handle path with unicode characters', async () => {
+    const { invokeTauri } = await import('../utils/tauri');
+    const { browseImages } = await import('../core/browse');
+    const unicodePath = '/path/with/日本語/中文/한글/folder';
+    vi.mocked(invokeTauri).mockResolvedValueOnce({ images: [], directories: [] });
+
+    await handleFileDrop([unicodePath]);
+
+    expect(browseImages).toHaveBeenCalledWith(unicodePath);
+  });
+
+  it('should handle concurrent file drops', async () => {
+    const { invokeTauri } = await import('../utils/tauri');
+    const { browseImages } = await import('../core/browse');
+    vi.mocked(invokeTauri).mockResolvedValue({ images: [], directories: [] });
+
+    await Promise.all([
+      handleFileDrop(['/path1']),
+      handleFileDrop(['/path2']),
+      handleFileDrop(['/path3']),
+    ]);
+
+    // All should be processed
+    expect(invokeTauri).toHaveBeenCalledTimes(3);
+    expect(browseImages).toHaveBeenCalled();
+  });
+
+  it('should handle parent directory fallback with relative path', async () => {
+    const { invokeTauri } = await import('../utils/tauri');
+    const { browseImages } = await import('../core/browse');
+    
+    vi.mocked(invokeTauri)
+      .mockRejectedValueOnce(new Error('Not a directory'))
+      .mockResolvedValueOnce('../parent');
+
+    await handleFileDrop(['./current/file.png']);
+
+    expect(browseImages).toHaveBeenCalledWith('../parent');
   });
 });
 

--- a/src/handlers/keyboard.test.ts
+++ b/src/handlers/keyboard.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, beforeEach, vi, afterEach } from "vitest";
 import { store } from "../utils/jotaiStore";
-import { currentModalIndexAtom, currentModalImagePathAtom, shortcutsOverlayVisibleAtom } from "../state";
+import { currentModalImagePathAtom, shortcutsOverlayVisibleAtom, resetStateAtom } from "../state";
 
 // Mock dependencies
 vi.mock("../ui/modal", async () => {
@@ -32,9 +32,7 @@ describe("keyboard handlers", () => {
     `;
 
     // Reset state (keyboard handler checks currentModalImagePath instead of DOM styles)
-    store.set(currentModalIndexAtom, -1);
-    store.set(currentModalImagePathAtom, "");
-    store.set(shortcutsOverlayVisibleAtom, false);
+    store.set(resetStateAtom);
 
     // Reset mocks
     vi.clearAllMocks();
@@ -85,7 +83,6 @@ describe("keyboard handlers", () => {
 
       // Set modal as open (state-based check)
       store.set(currentModalImagePathAtom, "/test/image1.png");
-      store.set(currentModalIndexAtom, 0);
 
       const event = new KeyboardEvent("keydown", { key: "ArrowLeft" });
       document.dispatchEvent(event);
@@ -101,7 +98,6 @@ describe("keyboard handlers", () => {
 
       // Set modal as open (state-based check)
       store.set(currentModalImagePathAtom, "/test/image1.png");
-      store.set(currentModalIndexAtom, 0);
 
       const event = new KeyboardEvent("keydown", { key: "ArrowRight" });
       document.dispatchEvent(event);
@@ -117,7 +113,6 @@ describe("keyboard handlers", () => {
 
       // Set modal as open and overlay as visible (state-based checks)
       store.set(currentModalImagePathAtom, "/test/image1.png");
-      store.set(currentModalIndexAtom, 0);
       store.set(shortcutsOverlayVisibleAtom, true);
 
       const event = new KeyboardEvent("keydown", { key: "Escape" });
@@ -135,7 +130,6 @@ describe("keyboard handlers", () => {
 
       // Set modal as open but overlay not visible (state-based checks)
       store.set(currentModalImagePathAtom, "/test/image1.png");
-      store.set(currentModalIndexAtom, 0);
       store.set(shortcutsOverlayVisibleAtom, false);
 
       const event = new KeyboardEvent("keydown", { key: "Escape" });
@@ -151,7 +145,6 @@ describe("keyboard handlers", () => {
 
       // Set modal as open (state-based check)
       store.set(currentModalImagePathAtom, "/test/image1.png");
-      store.set(currentModalIndexAtom, 0);
       store.set(shortcutsOverlayVisibleAtom, false);
 
       const event = new KeyboardEvent("keydown", { key: "?" });
@@ -168,7 +161,6 @@ describe("keyboard handlers", () => {
 
       // Set modal as open (state-based check)
       store.set(currentModalImagePathAtom, "/test/image1.png");
-      store.set(currentModalIndexAtom, 0);
       store.set(shortcutsOverlayVisibleAtom, false);
 
       const event = new KeyboardEvent("keydown", {
@@ -189,7 +181,6 @@ describe("keyboard handlers", () => {
 
       // Set modal as open (state-based check)
       store.set(currentModalImagePathAtom, "/test/image1.png");
-      store.set(currentModalIndexAtom, 0);
 
       const event = new KeyboardEvent("keydown", { key: "Delete" });
       document.dispatchEvent(event);
@@ -205,7 +196,6 @@ describe("keyboard handlers", () => {
 
       // Set modal as open (state-based check)
       store.set(currentModalImagePathAtom, "/test/image1.png");
-      store.set(currentModalIndexAtom, 0);
 
       const event = new KeyboardEvent("keydown", { key: "Backspace" });
       document.dispatchEvent(event);
@@ -221,7 +211,6 @@ describe("keyboard handlers", () => {
 
       // Set modal as open (state-based check)
       store.set(currentModalImagePathAtom, "/test/image1.png");
-      store.set(currentModalIndexAtom, 0);
 
       const event = new KeyboardEvent("keydown", { code: "Delete" });
       document.dispatchEvent(event);
@@ -237,7 +226,6 @@ describe("keyboard handlers", () => {
 
       // Set modal as open (state-based check)
       store.set(currentModalImagePathAtom, "/test/image1.png");
-      store.set(currentModalIndexAtom, 0);
 
       const event = new KeyboardEvent("keydown", { code: "Backspace" });
       document.dispatchEvent(event);
@@ -253,7 +241,6 @@ describe("keyboard handlers", () => {
 
       // Modal is closed (state-based check)
       store.set(currentModalImagePathAtom, "");
-      store.set(currentModalIndexAtom, -1);
 
       const event = new KeyboardEvent("keydown", { key: "ArrowRight" });
       document.dispatchEvent(event);
@@ -269,7 +256,6 @@ describe("keyboard handlers", () => {
 
       // Modal is closed (state-based check)
       store.set(currentModalImagePathAtom, "");
-      store.set(currentModalIndexAtom, -1);
 
       const event = new KeyboardEvent("keydown", { key: "ArrowRight" });
       document.dispatchEvent(event);
@@ -288,7 +274,6 @@ describe("keyboard handlers", () => {
 
       // Set modal as open (state-based check)
       store.set(currentModalImagePathAtom, "/test/image1.png");
-      store.set(currentModalIndexAtom, 0);
 
       const event = new KeyboardEvent("keydown", { key: "ArrowRight" });
       document.dispatchEvent(event);
@@ -364,7 +349,6 @@ describe("keyboard handlers", () => {
 
       // Set modal as open (state-based check)
       store.set(currentModalImagePathAtom, "/test/image1.png");
-      store.set(currentModalIndexAtom, 0);
 
       const event = new KeyboardEvent("keydown", { key: "ArrowLeft" });
       const preventDefaultSpy = vi.spyOn(event, "preventDefault");
@@ -381,7 +365,6 @@ describe("keyboard handlers", () => {
 
       // Set modal as open (state-based check)
       store.set(currentModalImagePathAtom, "/test/image1.png");
-      store.set(currentModalIndexAtom, 0);
 
       const event = new KeyboardEvent("keydown", { key: "ArrowRight" });
       const preventDefaultSpy = vi.spyOn(event, "preventDefault");
@@ -398,7 +381,6 @@ describe("keyboard handlers", () => {
 
       // Set modal as open (state-based check)
       store.set(currentModalImagePathAtom, "/test/image1.png");
-      store.set(currentModalIndexAtom, 0);
 
       const event = new KeyboardEvent("keydown", { key: "Escape" });
       const preventDefaultSpy = vi.spyOn(event, "preventDefault");
@@ -415,7 +397,6 @@ describe("keyboard handlers", () => {
 
       // Set modal as open (state-based check)
       store.set(currentModalImagePathAtom, "/test/image1.png");
-      store.set(currentModalIndexAtom, 0);
 
       const event = new KeyboardEvent("keydown", { key: "?" });
       const preventDefaultSpy = vi.spyOn(event, "preventDefault");
@@ -432,7 +413,6 @@ describe("keyboard handlers", () => {
 
       // Set modal as open (state-based check)
       store.set(currentModalImagePathAtom, "/test/image1.png");
-      store.set(currentModalIndexAtom, 0);
 
       const event = new KeyboardEvent("keydown", { key: "Delete" });
       const preventDefaultSpy = vi.spyOn(event, "preventDefault");
@@ -450,7 +430,6 @@ describe("keyboard handlers", () => {
 
       // Modal is closed (state-based check, not DOM style)
       store.set(currentModalImagePathAtom, "");
-      store.set(currentModalIndexAtom, -1);
 
       const event = new KeyboardEvent("keydown", { key: "ArrowRight" });
       document.dispatchEvent(event);
@@ -466,7 +445,6 @@ describe("keyboard handlers", () => {
 
       // Modal is closed (state-based check, not DOM style)
       store.set(currentModalImagePathAtom, "");
-      store.set(currentModalIndexAtom, -1);
 
       const event = new KeyboardEvent("keydown", { key: "ArrowRight" });
       document.dispatchEvent(event);
@@ -633,7 +611,6 @@ describe("keyboard handlers", () => {
 
       // Set modal as open (state-based check)
       store.set(currentModalImagePathAtom, "/test/image1.png");
-      store.set(currentModalIndexAtom, 0);
 
       const input = document.createElement("input");
       document.body.appendChild(input);

--- a/src/handlers/keyboard.test.ts
+++ b/src/handlers/keyboard.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, beforeEach, vi, afterEach } from "vitest";
-import { state } from "../state";
+import { store } from "../utils/jotaiStore";
+import { currentModalIndexAtom, currentModalImagePathAtom, shortcutsOverlayVisibleAtom } from "../state";
 
 // Mock dependencies
 vi.mock("../ui/modal", async () => {
@@ -30,9 +31,10 @@ describe("keyboard handlers", () => {
       <div id="keyboard-shortcuts-overlay"></div>
     `;
 
-    // Reset state (keyboard handler checks state.currentModalIndex instead of DOM styles)
-    state.currentModalIndex = -1;
-    state.shortcutsOverlayVisible = false;
+    // Reset state (keyboard handler checks currentModalImagePath instead of DOM styles)
+    store.set(currentModalIndexAtom, -1);
+    store.set(currentModalImagePathAtom, "");
+    store.set(shortcutsOverlayVisibleAtom, false);
 
     // Reset mocks
     vi.clearAllMocks();
@@ -82,8 +84,8 @@ describe("keyboard handlers", () => {
       setupKeyboardHandlers();
 
       // Set modal as open (state-based check)
-      state.currentModalImagePath = "/test/image1.png";
-      state.currentModalIndex = 0;
+      store.set(currentModalImagePathAtom, "/test/image1.png");
+      store.set(currentModalIndexAtom, 0);
 
       const event = new KeyboardEvent("keydown", { key: "ArrowLeft" });
       document.dispatchEvent(event);
@@ -98,8 +100,8 @@ describe("keyboard handlers", () => {
       setupKeyboardHandlers();
 
       // Set modal as open (state-based check)
-      state.currentModalImagePath = "/test/image1.png";
-      state.currentModalIndex = 0;
+      store.set(currentModalImagePathAtom, "/test/image1.png");
+      store.set(currentModalIndexAtom, 0);
 
       const event = new KeyboardEvent("keydown", { key: "ArrowRight" });
       document.dispatchEvent(event);
@@ -114,14 +116,14 @@ describe("keyboard handlers", () => {
       setupKeyboardHandlers();
 
       // Set modal as open and overlay as visible (state-based checks)
-      state.currentModalImagePath = "/test/image1.png";
-      state.currentModalIndex = 0;
-      state.shortcutsOverlayVisible = true;
+      store.set(currentModalImagePathAtom, "/test/image1.png");
+      store.set(currentModalIndexAtom, 0);
+      store.set(shortcutsOverlayVisibleAtom, true);
 
       const event = new KeyboardEvent("keydown", { key: "Escape" });
       document.dispatchEvent(event);
 
-      expect(state.shortcutsOverlayVisible).toBe(false);
+      expect(store.get(shortcutsOverlayVisibleAtom)).toBe(false);
       expect(closeModal).not.toHaveBeenCalled();
     });
 
@@ -132,9 +134,9 @@ describe("keyboard handlers", () => {
       setupKeyboardHandlers();
 
       // Set modal as open but overlay not visible (state-based checks)
-      state.currentModalImagePath = "/test/image1.png";
-      state.currentModalIndex = 0;
-      state.shortcutsOverlayVisible = false;
+      store.set(currentModalImagePathAtom, "/test/image1.png");
+      store.set(currentModalIndexAtom, 0);
+      store.set(shortcutsOverlayVisibleAtom, false);
 
       const event = new KeyboardEvent("keydown", { key: "Escape" });
       document.dispatchEvent(event);
@@ -148,15 +150,15 @@ describe("keyboard handlers", () => {
       setupKeyboardHandlers();
 
       // Set modal as open (state-based check)
-      state.currentModalImagePath = "/test/image1.png";
-      state.currentModalIndex = 0;
-      state.shortcutsOverlayVisible = false;
+      store.set(currentModalImagePathAtom, "/test/image1.png");
+      store.set(currentModalIndexAtom, 0);
+      store.set(shortcutsOverlayVisibleAtom, false);
 
       const event = new KeyboardEvent("keydown", { key: "?" });
       document.dispatchEvent(event);
 
       // Check that state was toggled
-      expect(state.shortcutsOverlayVisible).toBe(true);
+      expect(store.get(shortcutsOverlayVisibleAtom)).toBe(true);
     });
 
     it("should toggle shortcuts overlay on Shift+/", async () => {
@@ -165,9 +167,9 @@ describe("keyboard handlers", () => {
       setupKeyboardHandlers();
 
       // Set modal as open (state-based check)
-      state.currentModalImagePath = "/test/image1.png";
-      state.currentModalIndex = 0;
-      state.shortcutsOverlayVisible = false;
+      store.set(currentModalImagePathAtom, "/test/image1.png");
+      store.set(currentModalIndexAtom, 0);
+      store.set(shortcutsOverlayVisibleAtom, false);
 
       const event = new KeyboardEvent("keydown", {
         key: "/",
@@ -176,7 +178,7 @@ describe("keyboard handlers", () => {
       document.dispatchEvent(event);
 
       // Check that state was toggled
-      expect(state.shortcutsOverlayVisible).toBe(true);
+      expect(store.get(shortcutsOverlayVisibleAtom)).toBe(true);
     });
 
     it("should delete current image on Delete key", async () => {
@@ -186,8 +188,8 @@ describe("keyboard handlers", () => {
       setupKeyboardHandlers();
 
       // Set modal as open (state-based check)
-      state.currentModalImagePath = "/test/image1.png";
-      state.currentModalIndex = 0;
+      store.set(currentModalImagePathAtom, "/test/image1.png");
+      store.set(currentModalIndexAtom, 0);
 
       const event = new KeyboardEvent("keydown", { key: "Delete" });
       document.dispatchEvent(event);
@@ -202,8 +204,8 @@ describe("keyboard handlers", () => {
       setupKeyboardHandlers();
 
       // Set modal as open (state-based check)
-      state.currentModalImagePath = "/test/image1.png";
-      state.currentModalIndex = 0;
+      store.set(currentModalImagePathAtom, "/test/image1.png");
+      store.set(currentModalIndexAtom, 0);
 
       const event = new KeyboardEvent("keydown", { key: "Backspace" });
       document.dispatchEvent(event);
@@ -218,8 +220,8 @@ describe("keyboard handlers", () => {
       setupKeyboardHandlers();
 
       // Set modal as open (state-based check)
-      state.currentModalImagePath = "/test/image1.png";
-      state.currentModalIndex = 0;
+      store.set(currentModalImagePathAtom, "/test/image1.png");
+      store.set(currentModalIndexAtom, 0);
 
       const event = new KeyboardEvent("keydown", { code: "Delete" });
       document.dispatchEvent(event);
@@ -234,8 +236,8 @@ describe("keyboard handlers", () => {
       setupKeyboardHandlers();
 
       // Set modal as open (state-based check)
-      state.currentModalImagePath = "/test/image1.png";
-      state.currentModalIndex = 0;
+      store.set(currentModalImagePathAtom, "/test/image1.png");
+      store.set(currentModalIndexAtom, 0);
 
       const event = new KeyboardEvent("keydown", { code: "Backspace" });
       document.dispatchEvent(event);
@@ -250,8 +252,8 @@ describe("keyboard handlers", () => {
       setupKeyboardHandlers();
 
       // Modal is closed (state-based check)
-      state.currentModalImagePath = "";
-      state.currentModalIndex = -1;
+      store.set(currentModalImagePathAtom, "");
+      store.set(currentModalIndexAtom, -1);
 
       const event = new KeyboardEvent("keydown", { key: "ArrowRight" });
       document.dispatchEvent(event);
@@ -266,8 +268,8 @@ describe("keyboard handlers", () => {
       setupKeyboardHandlers();
 
       // Modal is closed (state-based check)
-      state.currentModalImagePath = "";
-      state.currentModalIndex = -1;
+      store.set(currentModalImagePathAtom, "");
+      store.set(currentModalIndexAtom, -1);
 
       const event = new KeyboardEvent("keydown", { key: "ArrowRight" });
       document.dispatchEvent(event);
@@ -285,8 +287,8 @@ describe("keyboard handlers", () => {
       setupKeyboardHandlers();
 
       // Set modal as open (state-based check)
-      state.currentModalImagePath = "/test/image1.png";
-      state.currentModalIndex = 0;
+      store.set(currentModalImagePathAtom, "/test/image1.png");
+      store.set(currentModalIndexAtom, 0);
 
       const event = new KeyboardEvent("keydown", { key: "ArrowRight" });
       document.dispatchEvent(event);
@@ -361,8 +363,8 @@ describe("keyboard handlers", () => {
       setupKeyboardHandlers();
 
       // Set modal as open (state-based check)
-      state.currentModalImagePath = "/test/image1.png";
-      state.currentModalIndex = 0;
+      store.set(currentModalImagePathAtom, "/test/image1.png");
+      store.set(currentModalIndexAtom, 0);
 
       const event = new KeyboardEvent("keydown", { key: "ArrowLeft" });
       const preventDefaultSpy = vi.spyOn(event, "preventDefault");
@@ -378,8 +380,8 @@ describe("keyboard handlers", () => {
       setupKeyboardHandlers();
 
       // Set modal as open (state-based check)
-      state.currentModalImagePath = "/test/image1.png";
-      state.currentModalIndex = 0;
+      store.set(currentModalImagePathAtom, "/test/image1.png");
+      store.set(currentModalIndexAtom, 0);
 
       const event = new KeyboardEvent("keydown", { key: "ArrowRight" });
       const preventDefaultSpy = vi.spyOn(event, "preventDefault");
@@ -395,8 +397,8 @@ describe("keyboard handlers", () => {
       setupKeyboardHandlers();
 
       // Set modal as open (state-based check)
-      state.currentModalImagePath = "/test/image1.png";
-      state.currentModalIndex = 0;
+      store.set(currentModalImagePathAtom, "/test/image1.png");
+      store.set(currentModalIndexAtom, 0);
 
       const event = new KeyboardEvent("keydown", { key: "Escape" });
       const preventDefaultSpy = vi.spyOn(event, "preventDefault");
@@ -412,8 +414,8 @@ describe("keyboard handlers", () => {
       setupKeyboardHandlers();
 
       // Set modal as open (state-based check)
-      state.currentModalImagePath = "/test/image1.png";
-      state.currentModalIndex = 0;
+      store.set(currentModalImagePathAtom, "/test/image1.png");
+      store.set(currentModalIndexAtom, 0);
 
       const event = new KeyboardEvent("keydown", { key: "?" });
       const preventDefaultSpy = vi.spyOn(event, "preventDefault");
@@ -429,8 +431,8 @@ describe("keyboard handlers", () => {
       setupKeyboardHandlers();
 
       // Set modal as open (state-based check)
-      state.currentModalImagePath = "/test/image1.png";
-      state.currentModalIndex = 0;
+      store.set(currentModalImagePathAtom, "/test/image1.png");
+      store.set(currentModalIndexAtom, 0);
 
       const event = new KeyboardEvent("keydown", { key: "Delete" });
       const preventDefaultSpy = vi.spyOn(event, "preventDefault");
@@ -447,8 +449,8 @@ describe("keyboard handlers", () => {
       setupKeyboardHandlers();
 
       // Modal is closed (state-based check, not DOM style)
-      state.currentModalImagePath = "";
-      state.currentModalIndex = -1;
+      store.set(currentModalImagePathAtom, "");
+      store.set(currentModalIndexAtom, -1);
 
       const event = new KeyboardEvent("keydown", { key: "ArrowRight" });
       document.dispatchEvent(event);
@@ -463,8 +465,8 @@ describe("keyboard handlers", () => {
       setupKeyboardHandlers();
 
       // Modal is closed (state-based check, not DOM style)
-      state.currentModalImagePath = "";
-      state.currentModalIndex = -1;
+      store.set(currentModalImagePathAtom, "");
+      store.set(currentModalIndexAtom, -1);
 
       const event = new KeyboardEvent("keydown", { key: "ArrowRight" });
       document.dispatchEvent(event);
@@ -630,8 +632,8 @@ describe("keyboard handlers", () => {
       setupKeyboardHandlers();
 
       // Set modal as open (state-based check)
-      state.currentModalImagePath = "/test/image1.png";
-      state.currentModalIndex = 0;
+      store.set(currentModalImagePathAtom, "/test/image1.png");
+      store.set(currentModalIndexAtom, 0);
 
       const input = document.createElement("input");
       document.body.appendChild(input);

--- a/src/handlers/keyboard.ts
+++ b/src/handlers/keyboard.ts
@@ -1,4 +1,5 @@
-import { state } from "../state";
+import { store } from "../utils/jotaiStore";
+import { currentModalImagePathAtom, shortcutsOverlayVisibleAtom } from "../state";
 import { closeModal, showPreviousImage, showNextImage, toggleShortcutsOverlay, deleteCurrentImage } from "../ui/modal";
 import { checkAndExecuteHotkey } from "../ui/hotkeys";
 
@@ -53,8 +54,9 @@ export function setupKeyboardHandlers(): void {
     // If typing in editable element, skip hotkey checks but continue to modal shortcuts
     
     // Only handle modal-specific shortcuts when modal is open
-    // Check state.currentModalImagePath instead of DOM element display style (React manages visibility)
-    if (!state.currentModalImagePath) {
+    // Check currentModalImagePathAtom instead of DOM element display style (React manages visibility)
+    const currentModalImagePath = store.get(currentModalImagePathAtom);
+    if (!currentModalImagePath) {
       return;
     }
     
@@ -66,8 +68,9 @@ export function setupKeyboardHandlers(): void {
       showNextImage();
     } else if (e.key === "Escape") {
       e.preventDefault();
-      // Check state.shortcutsOverlayVisible instead of DOM element display style
-      if (state.shortcutsOverlayVisible) {
+      // Check shortcutsOverlayVisibleAtom instead of DOM element display style
+      const shortcutsOverlayVisible = store.get(shortcutsOverlayVisibleAtom);
+      if (shortcutsOverlayVisible) {
         toggleShortcutsOverlay();
       } else {
         closeModal();

--- a/src/state.test.ts
+++ b/src/state.test.ts
@@ -6,7 +6,6 @@ import {
   currentIndexAtom,
   isLoadingBatchAtom,
   loadedImagesAtom,
-  currentModalIndexAtom,
   currentModalImagePathAtom,
   isDeletingImageAtom,
   hotkeysAtom,
@@ -23,6 +22,14 @@ import {
   hotkeyDialogHotkeyAtom,
   isLoadingAtom,
   errorMessageAtom,
+  sortOptionAtom,
+  sortDirectionAtom,
+  filterOptionsAtom,
+  selectionModeAtom,
+  selectedImagesAtom,
+  toggleImageSelectionAtom,
+  suppressCategoryRefilterAtom,
+  cachedImageCategoriesForRefilterAtom,
   resetStateAtom,
 } from './state';
 
@@ -39,7 +46,6 @@ describe('state', () => {
       expect(store.get(currentIndexAtom)).toBe(0);
       expect(store.get(isLoadingBatchAtom)).toBe(false);
       expect(store.get(loadedImagesAtom).size).toBe(0);
-      expect(store.get(currentModalIndexAtom)).toBe(-1);
       expect(store.get(currentModalImagePathAtom)).toBe('');
       expect(store.get(isDeletingImageAtom)).toBe(false);
       expect(store.get(hotkeysAtom)).toEqual([]);
@@ -55,6 +61,21 @@ describe('state', () => {
       expect(store.get(hotkeyDialogHotkeyAtom)).toBeUndefined();
       expect(store.get(isLoadingAtom)).toBe(false);
       expect(store.get(errorMessageAtom)).toBe('');
+      expect(store.get(sortOptionAtom)).toBe('name');
+      expect(store.get(sortDirectionAtom)).toBe('ascending');
+      expect(store.get(filterOptionsAtom)).toEqual({
+        categoryId: '',
+        namePattern: '',
+        nameOperator: 'contains',
+        sizeOperator: 'largerThan',
+        sizeValue: '',
+        sizeValue2: '',
+      });
+      expect(store.get(selectionModeAtom)).toBe(false);
+      expect(store.get(selectedImagesAtom).size).toBe(0);
+      expect(store.get(toggleImageSelectionAtom)).toBeUndefined();
+      expect(store.get(suppressCategoryRefilterAtom)).toBe(false);
+      expect(store.get(cachedImageCategoriesForRefilterAtom)).toBeNull();
     });
 
     it('should allow setting and getting values', () => {
@@ -80,7 +101,6 @@ describe('state', () => {
       store.set(isLoadingBatchAtom, true);
       const loadedImages = new Map([['/test/image.png', 'data-url']]);
       store.set(loadedImagesAtom, loadedImages);
-      store.set(currentModalIndexAtom, 2);
       store.set(currentModalImagePathAtom, '/test/image.png');
       store.set(isDeletingImageAtom, true);
       store.set(hotkeysAtom, [{ id: '1', key: 'A', modifiers: [], action: 'test' }]);
@@ -99,6 +119,21 @@ describe('state', () => {
       store.set(hotkeyDialogHotkeyAtom, { id: '1', key: 'A', modifiers: [], action: 'test' });
       store.set(isLoadingAtom, true);
       store.set(errorMessageAtom, 'Test error');
+      store.set(sortOptionAtom, 'dateCreated');
+      store.set(sortDirectionAtom, 'descending');
+      store.set(filterOptionsAtom, {
+        categoryId: 'cat1',
+        namePattern: 'test',
+        nameOperator: 'startsWith',
+        sizeOperator: 'between',
+        sizeValue: '100',
+        sizeValue2: '200',
+      });
+      store.set(selectionModeAtom, true);
+      store.set(selectedImagesAtom, new Set(['/test/image1.png', '/test/image2.png']));
+      store.set(toggleImageSelectionAtom, () => {});
+      store.set(suppressCategoryRefilterAtom, true);
+      store.set(cachedImageCategoriesForRefilterAtom, new Map([['/test/image.png', []]]));
       const resetCounterBefore = store.get(resetCounterAtom);
 
       store.set(resetStateAtom);
@@ -108,7 +143,6 @@ describe('state', () => {
       expect(store.get(currentIndexAtom)).toBe(0);
       expect(store.get(isLoadingBatchAtom)).toBe(false);
       expect(store.get(loadedImagesAtom).size).toBe(0);
-      expect(store.get(currentModalIndexAtom)).toBe(-1);
       expect(store.get(currentModalImagePathAtom)).toBe('');
       expect(store.get(isDeletingImageAtom)).toBe(false);
       expect(store.get(hotkeysAtom)).toEqual([]);
@@ -125,6 +159,21 @@ describe('state', () => {
       expect(store.get(hotkeyDialogHotkeyAtom)).toBeUndefined();
       expect(store.get(isLoadingAtom)).toBe(false);
       expect(store.get(errorMessageAtom)).toBe('');
+      expect(store.get(sortOptionAtom)).toBe('name');
+      expect(store.get(sortDirectionAtom)).toBe('ascending');
+      expect(store.get(filterOptionsAtom)).toEqual({
+        categoryId: '',
+        namePattern: '',
+        nameOperator: 'contains',
+        sizeOperator: 'largerThan',
+        sizeValue: '',
+        sizeValue2: '',
+      });
+      expect(store.get(selectionModeAtom)).toBe(false);
+      expect(store.get(selectedImagesAtom).size).toBe(0);
+      expect(store.get(toggleImageSelectionAtom)).toBeUndefined();
+      expect(store.get(suppressCategoryRefilterAtom)).toBe(false);
+      expect(store.get(cachedImageCategoriesForRefilterAtom)).toBeNull();
     });
 
     it('should increment resetCounter on each reset', () => {

--- a/src/state.ts
+++ b/src/state.ts
@@ -7,7 +7,6 @@ export const allDirectoryPathsAtom = atom<DirectoryPath[]>([]);
 export const currentIndexAtom = atom<number>(0);
 export const isLoadingBatchAtom = atom<boolean>(false);
 export const loadedImagesAtom = atom<Map<string, string>>(new Map<string, string>());
-export const currentModalIndexAtom = atom<number>(-1); // Deprecated: use currentModalImagePath
 export const currentModalImagePathAtom = atom<string>(""); // Current image path being viewed in modal (empty = closed)
 export const isDeletingImageAtom = atom<boolean>(false);
 export const hotkeysAtom = atom<HotkeyConfig[]>([]);
@@ -54,7 +53,6 @@ export const resetStateAtom = atom(null, (get, set) => {
   set(currentIndexAtom, 0);
   set(isLoadingBatchAtom, false);
   set(loadedImagesAtom, new Map<string, string>());
-  set(currentModalIndexAtom, -1);
   set(currentModalImagePathAtom, "");
   set(isDeletingImageAtom, false);
   set(hotkeysAtom, []);

--- a/src/ui/categories.ts
+++ b/src/ui/categories.ts
@@ -239,26 +239,6 @@ export function generateCategoryColor(): string {
 
 
 /**
- * Get a contrasting text color (black or white) based on background color brightness.
- */
-function getContrastColor(hexColor: string): string {
-  // Remove # if present
-  const hex = hexColor.replace("#", "");
-
-  // Convert to RGB
-  const r = parseInt(hex.substring(0, 2), 16);
-  const g = parseInt(hex.substring(2, 4), 16);
-  const b = parseInt(hex.substring(4, 6), 16);
-
-  // Calculate luminance
-  const luminance = (0.299 * r + 0.587 * g + 0.114 * b) / 255;
-
-  // Return black for light colors, white for dark colors
-  return luminance > 0.5 ? "#000000" : "#ffffff";
-}
-
-
-/**
  * Check if an image matches the current category filter.
  */
 function imageMatchesCategoryFilter(imagePath: string, filterCategoryId: string | "uncategorized" | ""): boolean {

--- a/src/ui/categories.ts
+++ b/src/ui/categories.ts
@@ -395,10 +395,13 @@ export async function toggleImageCategory(
   const updatedImageCategories = new Map(imageCategories);
   if (existingIndex >= 0) {
     // Remove category
-    updatedImageCategories.set(
-      imagePath,
-      currentAssignments.filter((_, index) => index !== existingIndex),
-    );
+    const updatedAssignments = currentAssignments.filter((_, index) => index !== existingIndex);
+    if (updatedAssignments.length === 0) {
+      // Delete entry when last assignment is removed, consistent with deleteCategory
+      updatedImageCategories.delete(imagePath);
+    } else {
+      updatedImageCategories.set(imagePath, updatedAssignments);
+    }
   } else {
     // Add category with current datetime
     updatedImageCategories.set(imagePath, [

--- a/src/ui/error.test.ts
+++ b/src/ui/error.test.ts
@@ -1,11 +1,11 @@
 import { describe, it, expect, beforeEach } from "vitest";
 import { showError, clearError } from "./error";
 import { store } from "../utils/jotaiStore";
-import { errorMessageAtom } from "../state";
+import { errorMessageAtom, resetStateAtom } from "../state";
 
 describe("error", () => {
   beforeEach(() => {
-    store.set(errorMessageAtom, "");
+    store.set(resetStateAtom);
   });
 
   describe("showError", () => {

--- a/src/ui/error.test.ts
+++ b/src/ui/error.test.ts
@@ -1,17 +1,18 @@
 import { describe, it, expect, beforeEach } from "vitest";
 import { showError, clearError } from "./error";
-import { state } from "../state";
+import { store } from "../utils/jotaiStore";
+import { errorMessageAtom } from "../state";
 
 describe("error", () => {
   beforeEach(() => {
-    state.errorMessage = "";
+    store.set(errorMessageAtom, "");
   });
 
   describe("showError", () => {
     it("should update state with error message", () => {
       showError("Test error message");
 
-      expect(state.errorMessage).toBe("Test error message");
+      expect(store.get(errorMessageAtom)).toBe("Test error message");
     });
 
     it("should not throw", () => {
@@ -21,23 +22,23 @@ describe("error", () => {
     it("should handle empty string", () => {
       showError("");
 
-      expect(state.errorMessage).toBe("");
+      expect(store.get(errorMessageAtom)).toBe("");
     });
 
     it("should overwrite previous error", () => {
       showError("First error");
       showError("Second error");
 
-      expect(state.errorMessage).toBe("Second error");
+      expect(store.get(errorMessageAtom)).toBe("Second error");
     });
   });
 
   describe("clearError", () => {
     it("should clear error message in state", () => {
-      state.errorMessage = "Some error";
+      store.set(errorMessageAtom, "Some error");
       clearError();
 
-      expect(state.errorMessage).toBe("");
+      expect(store.get(errorMessageAtom)).toBe("");
     });
 
     it("should not throw", () => {
@@ -45,10 +46,10 @@ describe("error", () => {
     });
 
     it("should clear already empty error", () => {
-      state.errorMessage = "";
+      store.set(errorMessageAtom, "");
       clearError();
 
-      expect(state.errorMessage).toBe("");
+      expect(store.get(errorMessageAtom)).toBe("");
     });
   });
 });

--- a/src/ui/error.ts
+++ b/src/ui/error.ts
@@ -1,4 +1,5 @@
-import { state } from "../state";
+import { store } from "../utils/jotaiStore";
+import { errorMessageAtom } from "../state";
 
 /**
  * Displays an error message in the designated error UI element.
@@ -6,15 +7,13 @@ import { state } from "../state";
  * @param message - The error text to show to the user
  */
 export function showError(message: string): void {
-  state.errorMessage = message;
-  state.notify();
+  store.set(errorMessageAtom, message);
 }
 
 /**
  * Clear any visible error message from the UI.
  */
 export function clearError(): void {
-  state.errorMessage = "";
-  state.notify();
+  store.set(errorMessageAtom, "");
 }
 

--- a/src/ui/hotkeys.test.ts
+++ b/src/ui/hotkeys.test.ts
@@ -4,7 +4,6 @@ import {
   hotkeysAtom,
   categoriesAtom,
   isHotkeySidebarOpenAtom,
-  currentModalIndexAtom,
   hotkeyDialogVisibleAtom,
   hotkeyDialogHotkeyAtom,
   resetStateAtom,
@@ -40,7 +39,6 @@ describe("hotkeys", () => {
     store.set(hotkeysAtom, []);
     store.set(categoriesAtom, []);
     store.set(isHotkeySidebarOpenAtom, false);
-    store.set(currentModalIndexAtom, -1);
     store.set(hotkeyDialogVisibleAtom, false);
     store.set(hotkeyDialogHotkeyAtom, undefined);
   });
@@ -68,7 +66,6 @@ describe("hotkeys", () => {
     });
 
     it("should not adjust modal image when opening sidebar with modal open", async () => {
-      store.set(currentModalIndexAtom, 0);
 
       const { toggleHotkeySidebar } = await import("./hotkeys");
       await toggleHotkeySidebar();
@@ -81,7 +78,6 @@ describe("hotkeys", () => {
 
     it("should not adjust modal image when closing sidebar with modal open", async () => {
       store.set(isHotkeySidebarOpenAtom, true);
-      store.set(currentModalIndexAtom, 0);
 
       const { toggleHotkeySidebar } = await import("./hotkeys");
       await toggleHotkeySidebar();
@@ -130,7 +126,6 @@ describe("hotkeys", () => {
     });
 
     it("should not adjust modal image when modal is open", async () => {
-      store.set(currentModalIndexAtom, 0);
 
       const { closeHotkeySidebar } = await import("./hotkeys");
       closeHotkeySidebar();

--- a/src/ui/hotkeys.test.ts
+++ b/src/ui/hotkeys.test.ts
@@ -1,5 +1,14 @@
 import { describe, it, expect, beforeEach, vi, afterEach } from "vitest";
-import { state } from "../state";
+import { store } from "../utils/jotaiStore";
+import {
+  hotkeysAtom,
+  categoriesAtom,
+  isHotkeySidebarOpenAtom,
+  currentModalIndexAtom,
+  hotkeyDialogVisibleAtom,
+  hotkeyDialogHotkeyAtom,
+  resetStateAtom,
+} from "../state";
 import type { HotkeyConfig } from "../types";
 
 // Mock dependencies
@@ -10,6 +19,8 @@ vi.mock("./categories", () => ({
 
 vi.mock("./modal", () => ({
   showNextImage: vi.fn(),
+  showPreviousImage: vi.fn(),
+  deleteCurrentImage: vi.fn(),
 }));
 
 vi.mock("../utils/dialog", () => ({
@@ -25,12 +36,13 @@ describe("hotkeys", () => {
     `;
 
     // Reset state
-    state.hotkeys = [];
-    state.categories = [];
-    state.isHotkeySidebarOpen = false;
-    state.currentModalIndex = -1;
-    state.hotkeyDialogVisible = false;
-    state.hotkeyDialogHotkey = undefined;
+    store.set(resetStateAtom);
+    store.set(hotkeysAtom, []);
+    store.set(categoriesAtom, []);
+    store.set(isHotkeySidebarOpenAtom, false);
+    store.set(currentModalIndexAtom, -1);
+    store.set(hotkeyDialogVisibleAtom, false);
+    store.set(hotkeyDialogHotkeyAtom, undefined);
   });
 
   afterEach(() => {
@@ -43,20 +55,20 @@ describe("hotkeys", () => {
       
       await toggleHotkeySidebar();
 
-      expect(state.isHotkeySidebarOpen).toBe(true);
+      expect(store.get(isHotkeySidebarOpenAtom)).toBe(true);
     });
 
     it("should close sidebar when open", async () => {
-      state.isHotkeySidebarOpen = true;
+      store.set(isHotkeySidebarOpenAtom, true);
 
       const { toggleHotkeySidebar } = await import("./hotkeys");
       await toggleHotkeySidebar();
 
-      expect(state.isHotkeySidebarOpen).toBe(false);
+      expect(store.get(isHotkeySidebarOpenAtom)).toBe(false);
     });
 
     it("should not adjust modal image when opening sidebar with modal open", async () => {
-      state.currentModalIndex = 0;
+      store.set(currentModalIndexAtom, 0);
 
       const { toggleHotkeySidebar } = await import("./hotkeys");
       await toggleHotkeySidebar();
@@ -68,8 +80,8 @@ describe("hotkeys", () => {
     });
 
     it("should not adjust modal image when closing sidebar with modal open", async () => {
-      state.isHotkeySidebarOpen = true;
-      state.currentModalIndex = 0;
+      store.set(isHotkeySidebarOpenAtom, true);
+      store.set(currentModalIndexAtom, 0);
 
       const { toggleHotkeySidebar } = await import("./hotkeys");
       await toggleHotkeySidebar();
@@ -81,20 +93,20 @@ describe("hotkeys", () => {
     });
 
     it("should render hotkey list when opening", async () => {
-      state.hotkeys = [
+      store.set(hotkeysAtom, [
         {
           id: "hotkey1",
           key: "K",
           modifiers: ["Ctrl"],
           action: "toggle_category_cat1",
         },
-      ];
+      ]);
 
       const { toggleHotkeySidebar } = await import("./hotkeys");
       await toggleHotkeySidebar();
 
       // Function just toggles state, React component handles rendering
-      expect(state.isHotkeySidebarOpen).toBe(true);
+      expect(store.get(isHotkeySidebarOpenAtom)).toBe(true);
     });
 
     it("should handle missing sidebar element gracefully", async () => {
@@ -109,16 +121,16 @@ describe("hotkeys", () => {
 
   describe("closeHotkeySidebar", () => {
     it("should close sidebar", async () => {
-      state.isHotkeySidebarOpen = true;
+      store.set(isHotkeySidebarOpenAtom, true);
 
       const { closeHotkeySidebar } = await import("./hotkeys");
       closeHotkeySidebar();
 
-      expect(state.isHotkeySidebarOpen).toBe(false);
+      expect(store.get(isHotkeySidebarOpenAtom)).toBe(false);
     });
 
     it("should not adjust modal image when modal is open", async () => {
-      state.currentModalIndex = 0;
+      store.set(currentModalIndexAtom, 0);
 
       const { closeHotkeySidebar } = await import("./hotkeys");
       closeHotkeySidebar();
@@ -141,7 +153,7 @@ describe("hotkeys", () => {
 
   describe("checkAndExecuteHotkey", () => {
     beforeEach(() => {
-      state.hotkeys = [
+      store.set(hotkeysAtom, [
         {
           id: "hotkey1",
           key: "K",
@@ -154,7 +166,7 @@ describe("hotkeys", () => {
           modifiers: ["Ctrl", "Shift"],
           action: "toggle_category_cat2",
         },
-      ];
+      ]);
     });
 
     it("should match and execute hotkey with Ctrl modifier", async () => {
@@ -177,14 +189,14 @@ describe("hotkeys", () => {
 
     it("should match and execute hotkey with Cmd modifier on Mac", async () => {
       // Use a hotkey with Cmd modifier for Mac
-      state.hotkeys = [
+      store.set(hotkeysAtom, [
         {
           id: "hotkey1",
           key: "K",
           modifiers: ["Cmd"],
           action: "toggle_category_cat1",
         },
-      ];
+      ]);
 
       const { checkAndExecuteHotkey } = await import("./hotkeys");
       const { toggleCategoryForCurrentImage } = await import("./categories");
@@ -263,14 +275,14 @@ describe("hotkeys", () => {
     });
 
     it("should handle special keys (non-letter)", async () => {
-      state.hotkeys = [
+      store.set(hotkeysAtom, [
         {
           id: "hotkey3",
           key: "ArrowRight",
           modifiers: [],
           action: "next_image",
         },
-      ];
+      ]);
 
       const { checkAndExecuteHotkey } = await import("./hotkeys");
 
@@ -360,14 +372,14 @@ describe("hotkeys", () => {
 
   describe("checkAndExecuteHotkey", () => {
     beforeEach(() => {
-      state.hotkeys = [];
+      store.set(hotkeysAtom, []);
     });
 
     it("should handle errors in executeHotkeyAction gracefully", async () => {
       const consoleSpy = vi.spyOn(console, "error").mockImplementation(() => {});
-      state.hotkeys = [
+      store.set(hotkeysAtom, [
         { id: "h1", key: "K", modifiers: ["Ctrl"], action: "unknown_action_that_will_fail" },
-      ];
+      ]);
 
       const { checkAndExecuteHotkey } = await import("./hotkeys");
       const event = new KeyboardEvent("keydown", {
@@ -431,32 +443,32 @@ describe("hotkeys", () => {
       expect(sidebar.onclick).toBeDefined();
 
       // Test toggle button
-      state.isHotkeySidebarOpen = false;
+      store.set(isHotkeySidebarOpenAtom, false);
       if (sidebarToggle.onclick) {
         (sidebarToggle.onclick as () => void)();
       }
-      expect(state.isHotkeySidebarOpen).toBe(true);
+      expect(store.get(isHotkeySidebarOpenAtom)).toBe(true);
 
       // Test close button
       if (sidebarClose.onclick) {
         (sidebarClose.onclick as () => void)();
       }
-      expect(state.isHotkeySidebarOpen).toBe(false);
+      expect(store.get(isHotkeySidebarOpenAtom)).toBe(false);
 
       // Test add hotkey button
       if (addHotkeyBtn.onclick) {
         (addHotkeyBtn.onclick as () => void)();
       }
-      expect(state.hotkeyDialogVisible).toBe(true);
+      expect(store.get(hotkeyDialogVisibleAtom)).toBe(true);
 
       // Test sidebar click outside
-      state.isHotkeySidebarOpen = true;
+      store.set(isHotkeySidebarOpenAtom, true);
       const clickEvent = new MouseEvent("click", { bubbles: true });
       Object.defineProperty(clickEvent, "target", { value: sidebar, writable: false });
       if (sidebar.onclick) {
         (sidebar.onclick as (e: MouseEvent) => void)(clickEvent);
       }
-      expect(state.isHotkeySidebarOpen).toBe(false);
+      expect(store.get(isHotkeySidebarOpenAtom)).toBe(false);
     });
 
     it("should handle missing sidebar toggle button", async () => {
@@ -524,14 +536,14 @@ describe("hotkeys", () => {
       const { setupHotkeySidebar } = await import("./hotkeys");
       setupHotkeySidebar();
 
-      state.isHotkeySidebarOpen = true;
+      store.set(isHotkeySidebarOpenAtom, true);
       const clickEvent = new MouseEvent("click", { bubbles: true });
       Object.defineProperty(clickEvent, "target", { value: innerButton, writable: false });
       if (sidebar.onclick) {
         (sidebar.onclick as (e: MouseEvent) => void)(clickEvent);
       }
       // Sidebar should remain open when clicking inside
-      expect(state.isHotkeySidebarOpen).toBe(true);
+      expect(store.get(isHotkeySidebarOpenAtom)).toBe(true);
     });
   });
 
@@ -542,8 +554,8 @@ describe("hotkeys", () => {
       showHotkeyDialog();
       
       // Function sets state.hotkeyDialogVisible = true
-      expect(state.hotkeyDialogVisible).toBe(true);
-      expect(state.hotkeyDialogHotkey).toBeUndefined();
+      expect(store.get(hotkeyDialogVisibleAtom)).toBe(true);
+      expect(store.get(hotkeyDialogHotkeyAtom)).toBeUndefined();
     });
 
     it("should set state for editing existing hotkey", async () => {
@@ -558,17 +570,17 @@ describe("hotkeys", () => {
       showHotkeyDialog(hotkey);
       
       // Function sets state for editing
-      expect(state.hotkeyDialogVisible).toBe(true);
-      expect(state.hotkeyDialogHotkey).toEqual(hotkey);
+      expect(store.get(hotkeyDialogVisibleAtom)).toBe(true);
+      expect(store.get(hotkeyDialogHotkeyAtom)).toEqual(hotkey);
     });
   });
 
   describe("deleteHotkey", () => {
     it("should delete hotkey when called directly", async () => {
-      state.hotkeys = [
+      store.set(hotkeysAtom, [
         { id: "h1", key: "A", modifiers: ["Ctrl"], action: "toggle_category_cat1" },
         { id: "h2", key: "B", modifiers: ["Ctrl"], action: "toggle_category_cat2" },
-      ];
+      ]);
 
       const { confirm } = await import("../utils/dialog");
       vi.mocked(confirm).mockResolvedValue(true);
@@ -577,12 +589,19 @@ describe("hotkeys", () => {
       await deleteHotkey("h1");
 
       // Hotkey should be removed
-      expect(state.hotkeys).toHaveLength(1);
-      expect(state.hotkeys[0].id).toBe("h2");
+      expect(store.get(hotkeysAtom)).toHaveLength(1);
+      expect(store.get(hotkeysAtom)[0].id).toBe("h2");
     });
   });
 
   describe("populateActionDropdown", () => {
+    beforeEach(() => {
+      store.set(categoriesAtom, [
+        { id: "cat1", name: "Category 1", color: "#ff0000" },
+        { id: "cat2", name: "Category 2", color: "#00ff00" },
+      ]);
+    });
+
     it("should populate dropdown when called with select element", async () => {
       const select = document.createElement("select");
       // Add a placeholder option
@@ -590,11 +609,6 @@ describe("hotkeys", () => {
       placeholder.value = "";
       placeholder.textContent = "Select action...";
       select.appendChild(placeholder);
-      
-      state.categories = [
-        { id: "cat1", name: "Category 1", color: "#ff0000" },
-        { id: "cat2", name: "Category 2", color: "#00ff00" },
-      ];
 
       const { populateActionDropdown } = await import("./hotkeys");
       populateActionDropdown(select);
@@ -604,6 +618,431 @@ describe("hotkeys", () => {
       // Check for navigation actions
       const nextImageOption = Array.from(select.options).find(opt => opt.value === "next_image");
       expect(nextImageOption).toBeTruthy();
+    });
+
+    it("should include all navigation actions", async () => {
+      const select = document.createElement("select");
+      const placeholder = document.createElement("option");
+      placeholder.value = "";
+      placeholder.textContent = "Select action...";
+      select.appendChild(placeholder);
+
+      const { populateActionDropdown } = await import("./hotkeys");
+      populateActionDropdown(select);
+
+      const optionValues = Array.from(select.options).map(opt => opt.value);
+      expect(optionValues).toContain("next_image");
+      expect(optionValues).toContain("previous_image");
+      expect(optionValues).toContain("delete_image_and_next");
+    });
+
+    it("should include category toggle actions when categories exist", async () => {
+      const select = document.createElement("select");
+      const placeholder = document.createElement("option");
+      placeholder.value = "";
+      placeholder.textContent = "Select action...";
+      select.appendChild(placeholder);
+
+      const { populateActionDropdown } = await import("./hotkeys");
+      populateActionDropdown(select);
+
+      const optionValues = Array.from(select.options).map(opt => opt.value);
+      expect(optionValues).toContain("toggle_category_cat1");
+      expect(optionValues).toContain("toggle_category_cat2");
+      expect(optionValues).toContain("toggle_category_next_cat1");
+      expect(optionValues).toContain("toggle_category_next_cat2");
+    });
+
+    it("should show message when no categories exist", async () => {
+      store.set(categoriesAtom, []);
+      const select = document.createElement("select");
+      const placeholder = document.createElement("option");
+      placeholder.value = "";
+      placeholder.textContent = "Select action...";
+      select.appendChild(placeholder);
+
+      const { populateActionDropdown } = await import("./hotkeys");
+      populateActionDropdown(select);
+
+      const optionValues = Array.from(select.options).map(opt => opt.value);
+      const noCategoriesOption = Array.from(select.options).find(
+        opt => opt.textContent?.includes("No categories available")
+      );
+      expect(noCategoriesOption).toBeTruthy();
+      expect(noCategoriesOption?.disabled).toBe(true);
+    });
+
+    it("should preserve placeholder option", async () => {
+      const select = document.createElement("select");
+      const placeholder = document.createElement("option");
+      placeholder.value = "";
+      placeholder.textContent = "Select action...";
+      select.appendChild(placeholder);
+
+      const { populateActionDropdown } = await import("./hotkeys");
+      populateActionDropdown(select);
+
+      expect(select.options[0].value).toBe("");
+      expect(select.options[0].textContent).toBe("Select action...");
+    });
+
+    it("should set existing action value when provided", async () => {
+      const select = document.createElement("select");
+      const placeholder = document.createElement("option");
+      placeholder.value = "";
+      placeholder.textContent = "Select action...";
+      select.appendChild(placeholder);
+
+      const { populateActionDropdown } = await import("./hotkeys");
+      populateActionDropdown(select, "toggle_category_cat1");
+
+      expect(select.value).toBe("toggle_category_cat1");
+    });
+
+    it("should handle missing category action gracefully", async () => {
+      const select = document.createElement("select");
+      const placeholder = document.createElement("option");
+      placeholder.value = "";
+      placeholder.textContent = "Select action...";
+      select.appendChild(placeholder);
+
+      const { populateActionDropdown } = await import("./hotkeys");
+      populateActionDropdown(select, "toggle_category_deleted_cat");
+
+      // Should add disabled option for missing category
+      const missingOption = Array.from(select.options).find(
+        opt => opt.value === "toggle_category_deleted_cat" && opt.disabled
+      );
+      expect(missingOption).toBeTruthy();
+      expect(select.value).toBe("toggle_category_deleted_cat");
+    });
+
+    it("should clear existing options except placeholder", async () => {
+      const select = document.createElement("select");
+      const placeholder = document.createElement("option");
+      placeholder.value = "";
+      placeholder.textContent = "Select action...";
+      select.appendChild(placeholder);
+      
+      // Add some old options
+      const oldOption = document.createElement("option");
+      oldOption.value = "old_action";
+      oldOption.textContent = "Old Action";
+      select.appendChild(oldOption);
+
+      const { populateActionDropdown } = await import("./hotkeys");
+      populateActionDropdown(select);
+
+      // Old option should be removed
+      const oldOptionStillExists = Array.from(select.options).some(
+        opt => opt.value === "old_action"
+      );
+      expect(oldOptionStillExists).toBe(false);
+      // Placeholder should remain
+      expect(select.options[0].value).toBe("");
+    });
+  });
+
+  describe("formatHotkeyDisplay", () => {
+    it("should format hotkey with single modifier", async () => {
+      const { formatHotkeyDisplay } = await import("./hotkeys");
+      const hotkey = {
+        id: "h1",
+        key: "K",
+        modifiers: ["Ctrl"],
+        action: "next_image",
+      };
+
+      const display = formatHotkeyDisplay(hotkey);
+
+      expect(display).toBe("Ctrl + K");
+    });
+
+    it("should format hotkey with multiple modifiers", async () => {
+      const { formatHotkeyDisplay } = await import("./hotkeys");
+      const hotkey = {
+        id: "h1",
+        key: "K",
+        modifiers: ["Ctrl", "Shift", "Alt"],
+        action: "next_image",
+      };
+
+      const display = formatHotkeyDisplay(hotkey);
+
+      expect(display).toBe("Ctrl + Shift + Alt + K");
+    });
+
+    it("should format hotkey without modifiers", async () => {
+      const { formatHotkeyDisplay } = await import("./hotkeys");
+      const hotkey = {
+        id: "h1",
+        key: "J",
+        modifiers: [],
+        action: "next_image",
+      };
+
+      const display = formatHotkeyDisplay(hotkey);
+
+      expect(display).toBe("J");
+    });
+
+    it("should format hotkey with special key", async () => {
+      const { formatHotkeyDisplay } = await import("./hotkeys");
+      const hotkey = {
+        id: "h1",
+        key: "ArrowRight",
+        modifiers: ["Ctrl"],
+        action: "next_image",
+      };
+
+      const display = formatHotkeyDisplay(hotkey);
+
+      expect(display).toBe("Ctrl + ArrowRight");
+    });
+  });
+
+  describe("isHotkeyDuplicate", () => {
+    beforeEach(() => {
+      store.set(hotkeysAtom, [
+        { id: "h1", key: "K", modifiers: ["Ctrl"], action: "next_image" },
+        { id: "h2", key: "J", modifiers: ["Ctrl", "Shift"], action: "previous_image" },
+        { id: "h3", key: "L", modifiers: [], action: "delete_image" },
+      ]);
+    });
+
+    it("should detect duplicate key and modifiers", async () => {
+      const { isHotkeyDuplicate } = await import("./hotkeys");
+
+      expect(isHotkeyDuplicate("K", ["Ctrl"])).toBe(true);
+      expect(isHotkeyDuplicate("J", ["Ctrl", "Shift"])).toBe(true);
+    });
+
+    it("should not detect duplicate when key differs", async () => {
+      const { isHotkeyDuplicate } = await import("./hotkeys");
+
+      expect(isHotkeyDuplicate("X", ["Ctrl"])).toBe(false);
+    });
+
+    it("should not detect duplicate when modifiers differ", async () => {
+      const { isHotkeyDuplicate } = await import("./hotkeys");
+
+      expect(isHotkeyDuplicate("K", ["Alt"])).toBe(false);
+      expect(isHotkeyDuplicate("K", ["Ctrl", "Shift"])).toBe(false);
+    });
+
+    it("should not detect duplicate when modifiers are in different order", async () => {
+      const { isHotkeyDuplicate } = await import("./hotkeys");
+
+      // Modifiers are sorted before comparison, so order shouldn't matter
+      expect(isHotkeyDuplicate("J", ["Shift", "Ctrl"])).toBe(true);
+    });
+
+    it("should exclude specified hotkey ID from check", async () => {
+      const { isHotkeyDuplicate } = await import("./hotkeys");
+
+      // Should not be duplicate if we're editing the same hotkey
+      expect(isHotkeyDuplicate("K", ["Ctrl"], "h1")).toBe(false);
+      // But should be duplicate if editing a different hotkey
+      expect(isHotkeyDuplicate("K", ["Ctrl"], "h2")).toBe(true);
+    });
+
+    it("should handle empty modifiers array", async () => {
+      const { isHotkeyDuplicate } = await import("./hotkeys");
+
+      expect(isHotkeyDuplicate("L", [])).toBe(true);
+      expect(isHotkeyDuplicate("M", [])).toBe(false);
+    });
+
+    it("should handle case sensitivity for keys", async () => {
+      const { isHotkeyDuplicate } = await import("./hotkeys");
+
+      // Keys are case-sensitive in the check
+      expect(isHotkeyDuplicate("k", ["Ctrl"])).toBe(false); // lowercase k
+      expect(isHotkeyDuplicate("K", ["Ctrl"])).toBe(true); // uppercase K
+    });
+  });
+
+  describe("editHotkey", () => {
+    it("should open dialog with existing hotkey", async () => {
+      store.set(hotkeysAtom, [
+        { id: "h1", key: "K", modifiers: ["Ctrl"], action: "next_image" },
+      ]);
+
+      const { editHotkey } = await import("./hotkeys");
+      editHotkey("h1");
+
+      expect(store.get(hotkeyDialogVisibleAtom)).toBe(true);
+      expect(store.get(hotkeyDialogHotkeyAtom)?.id).toBe("h1");
+    });
+
+    it("should not open dialog if hotkey not found", async () => {
+      store.set(hotkeysAtom, [
+        { id: "h1", key: "K", modifiers: ["Ctrl"], action: "next_image" },
+      ]);
+
+      const { editHotkey } = await import("./hotkeys");
+      editHotkey("nonexistent");
+
+      expect(store.get(hotkeyDialogVisibleAtom)).toBe(false);
+    });
+  });
+
+  describe("executeHotkeyAction", () => {
+    it("should execute next_image action", async () => {
+      const { executeHotkeyAction } = await import("./hotkeys");
+      const { showNextImage } = await import("./modal");
+
+      await executeHotkeyAction("next_image");
+
+      expect(showNextImage).toHaveBeenCalled();
+    });
+
+    it("should execute previous_image action", async () => {
+      const { executeHotkeyAction } = await import("./hotkeys");
+      const { showPreviousImage } = await import("./modal");
+
+      await executeHotkeyAction("previous_image");
+
+      expect(showPreviousImage).toHaveBeenCalled();
+    });
+
+    it("should execute delete_image_and_next action", async () => {
+      const { executeHotkeyAction } = await import("./hotkeys");
+      const { deleteCurrentImage } = await import("./modal");
+
+      await executeHotkeyAction("delete_image_and_next");
+
+      expect(deleteCurrentImage).toHaveBeenCalled();
+    });
+
+    it("should handle legacy assign_category actions", async () => {
+      const { executeHotkeyAction } = await import("./hotkeys");
+      const { toggleCategoryForCurrentImage } = await import("./categories");
+
+      await executeHotkeyAction("assign_category_cat1");
+
+      expect(toggleCategoryForCurrentImage).toHaveBeenCalledWith("cat1");
+    });
+
+    it("should handle assign_category_image action (legacy)", async () => {
+      const { executeHotkeyAction } = await import("./hotkeys");
+      const { toggleCategoryForCurrentImage } = await import("./categories");
+
+      await executeHotkeyAction("assign_category_cat1_image");
+
+      expect(toggleCategoryForCurrentImage).toHaveBeenCalledWith("cat1_image");
+    });
+
+    it("should not move to next for legacy assign actions", async () => {
+      const { executeHotkeyAction } = await import("./hotkeys");
+      const { showNextImage } = await import("./modal");
+
+      await executeHotkeyAction("assign_category_cat1");
+
+      expect(showNextImage).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("checkAndExecuteHotkey modifier handling", () => {
+    beforeEach(() => {
+      store.set(hotkeysAtom, [
+        { id: "h1", key: "K", modifiers: ["Alt"], action: "next_image" },
+        { id: "h2", key: "J", modifiers: ["Shift"], action: "previous_image" },
+        { id: "h3", key: "L", modifiers: ["Ctrl", "Alt"], action: "delete_image_and_next" },
+      ]);
+    });
+
+    it("should match Alt modifier", async () => {
+      const { checkAndExecuteHotkey } = await import("./hotkeys");
+      const { showNextImage } = await import("./modal");
+
+      const event = new KeyboardEvent("keydown", {
+        key: "k",
+        altKey: true,
+        ctrlKey: false,
+        shiftKey: false,
+      });
+
+      const result = checkAndExecuteHotkey(event);
+
+      expect(result).toBe(true);
+      await new Promise(resolve => setTimeout(resolve, 10));
+      expect(showNextImage).toHaveBeenCalled();
+    });
+
+    it("should match Shift modifier", async () => {
+      const { checkAndExecuteHotkey } = await import("./hotkeys");
+      const { showPreviousImage } = await import("./modal");
+
+      const event = new KeyboardEvent("keydown", {
+        key: "j",
+        shiftKey: true,
+        ctrlKey: false,
+        altKey: false,
+      });
+
+      const result = checkAndExecuteHotkey(event);
+
+      expect(result).toBe(true);
+      await new Promise(resolve => setTimeout(resolve, 10));
+      expect(showPreviousImage).toHaveBeenCalled();
+    });
+
+    it("should match multiple modifiers", async () => {
+      const { checkAndExecuteHotkey } = await import("./hotkeys");
+      const { deleteCurrentImage } = await import("./modal");
+
+      const event = new KeyboardEvent("keydown", {
+        key: "l",
+        ctrlKey: true,
+        altKey: true,
+        shiftKey: false,
+      });
+
+      const result = checkAndExecuteHotkey(event);
+
+      expect(result).toBe(true);
+      await new Promise(resolve => setTimeout(resolve, 10));
+      expect(deleteCurrentImage).toHaveBeenCalled();
+    });
+
+    it("should not match when modifier count differs", async () => {
+      const { checkAndExecuteHotkey } = await import("./hotkeys");
+
+      const event = new KeyboardEvent("keydown", {
+        key: "K",
+        altKey: true,
+        ctrlKey: true, // Extra modifier
+        shiftKey: false,
+      });
+
+      const result = checkAndExecuteHotkey(event);
+
+      expect(result).toBe(false);
+    });
+  });
+
+  describe("deleteHotkey error handling", () => {
+    it("should handle save errors gracefully", async () => {
+      store.set(hotkeysAtom, [
+        { id: "h1", key: "K", modifiers: ["Ctrl"], action: "next_image" },
+      ]);
+
+      const { confirm } = await import("../utils/dialog");
+      const { saveHitoConfig } = await import("./categories");
+      vi.mocked(confirm).mockResolvedValue(true);
+      vi.mocked(saveHitoConfig).mockRejectedValueOnce(new Error("Save failed"));
+
+      const consoleSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+
+      const { deleteHotkey } = await import("./hotkeys");
+      await deleteHotkey("h1");
+
+      // Hotkey should still be deleted from state
+      expect(store.get(hotkeysAtom)).toHaveLength(0);
+      // Error should be logged
+      expect(consoleSpy).toHaveBeenCalled();
+      consoleSpy.mockRestore();
     });
   });
 });

--- a/src/ui/modal.test.ts
+++ b/src/ui/modal.test.ts
@@ -1,5 +1,22 @@
 import { describe, it, expect, beforeEach, vi } from "vitest";
-import { state } from "../state";
+import { store } from "../utils/jotaiStore";
+import {
+  allImagePathsAtom,
+  currentModalIndexAtom,
+  currentModalImagePathAtom,
+  isDeletingImageAtom,
+  loadedImagesAtom,
+  hotkeysAtom,
+  categoriesAtom,
+  shortcutsOverlayVisibleAtom,
+  filterOptionsAtom,
+  sortOptionAtom,
+  sortDirectionAtom,
+  currentIndexAtom,
+  resetStateAtom,
+  suppressCategoryRefilterAtom,
+  cachedImageCategoriesForRefilterAtom,
+} from "../state";
 import {
   openModal,
   openModalByIndex,
@@ -9,6 +26,7 @@ import {
   toggleShortcutsOverlay,
   deleteCurrentImage,
 } from "./modal";
+import type { ImagePath } from "../types";
 
 // Mock dependencies
 vi.mock("../utils/images", () => ({
@@ -33,31 +51,37 @@ vi.mock("../utils/tauri", () => ({
   isTauriInvokeAvailable: vi.fn().mockReturnValue(true),
 }));
 
+vi.mock("../utils/filteredImages", () => ({
+  getFilteredAndSortedImagesSync: vi.fn().mockReturnValue([]),
+  getFilteredAndSortedImages: vi.fn().mockResolvedValue([]),
+}));
+
 describe("modal", () => {
-  beforeEach(() => {
+  beforeEach(async () => {
     // Reset state
-    state.allImagePaths = [
+    store.set(resetStateAtom);
+    store.set(allImagePathsAtom, [
       { path: "/test/image1.png" },
       { path: "/test/image2.png" },
       { path: "/test/image3.png" },
-    ];
-    state.currentModalIndex = -1;
-    state.currentModalImagePath = "";
-    state.isDeletingImage = false;
-    state.loadedImages.clear();
-    state.hotkeys = [];
-    state.categories = [];
-    state.shortcutsOverlayVisible = false;
-    state.filterOptions = {
+    ]);
+    store.set(currentModalIndexAtom, -1);
+    store.set(currentModalImagePathAtom, "");
+    store.set(isDeletingImageAtom, false);
+    store.set(loadedImagesAtom, new Map());
+    store.set(hotkeysAtom, []);
+    store.set(categoriesAtom, []);
+    store.set(shortcutsOverlayVisibleAtom, false);
+    store.set(filterOptionsAtom, {
       categoryId: "",
       namePattern: "",
       nameOperator: "contains",
       sizeOperator: "largerThan",
       sizeValue: "",
       sizeValue2: "",
-    };
-    state.sortOption = "name";
-    state.sortDirection = "ascending";
+    });
+    store.set(sortOptionAtom, "name");
+    store.set(sortDirectionAtom, "ascending");
 
     // Mock window.__TAURI__
     (window as any).__TAURI__ = {
@@ -65,17 +89,22 @@ describe("modal", () => {
         invoke: vi.fn(),
       },
     };
+
+    // Setup default mock for getFilteredAndSortedImagesSync to return images matching allImagePathsAtom
+    const { getFilteredAndSortedImagesSync } = await import("../utils/filteredImages");
+    const allImagePaths = store.get(allImagePathsAtom);
+    vi.mocked(getFilteredAndSortedImagesSync).mockReturnValue(allImagePaths);
   });
 
   describe("openModal", () => {
     it("should return early if allImagePaths is not an array", async () => {
       const consoleSpy = vi.spyOn(console, "error").mockImplementation(() => {});
-      (state as any).allImagePaths = null;
+      store.set(allImagePathsAtom, null as any);
 
       await openModalByIndex(0);
 
       expect(consoleSpy).toHaveBeenCalled();
-      expect(state.allImagePaths).toEqual([]);
+      expect(store.get(allImagePathsAtom)).toEqual([]);
       consoleSpy.mockRestore();
     });
 
@@ -83,25 +112,28 @@ describe("modal", () => {
       await openModalByIndex(-1);
       await openModalByIndex(100);
 
-      expect(state.currentModalIndex).toBe(-1);
-      expect(state.currentModalImagePath).toBe("");
+      expect(store.get(currentModalIndexAtom)).toBe(-1);
+      expect(store.get(currentModalImagePathAtom)).toBe("");
     });
 
     it("should return early if modal elements are missing", async () => {
       // This test verifies state is set correctly
       await openModalByIndex(0);
 
-      expect(state.currentModalIndex).toBe(0);
+      expect(store.get(currentModalIndexAtom)).toBe(0);
     });
 
     it("should open modal with cached image", async () => {
-      state.loadedImages.set("/test/image1.png", "cached-data-url");
+      const loadedImages = store.get(loadedImagesAtom);
+      const updatedLoadedImages = new Map(loadedImages);
+      updatedLoadedImages.set("/test/image1.png", "cached-data-url");
+      store.set(loadedImagesAtom, updatedLoadedImages);
 
       await openModalByIndex(0);
 
       // React component handles rendering - we just verify state
-      expect(state.currentModalIndex).toBe(0);
-      expect(state.loadedImages.get("/test/image1.png")).toBe("cached-data-url");
+      expect(store.get(currentModalIndexAtom)).toBe(0);
+      expect(store.get(loadedImagesAtom).get("/test/image1.png")).toBe("cached-data-url");
     });
 
     it("should load image if not cached", async () => {
@@ -110,7 +142,7 @@ describe("modal", () => {
       await openModalByIndex(0);
 
       expect(loadImageData).toHaveBeenCalledWith("/test/image1.png");
-      expect(state.currentModalIndex).toBe(0);
+      expect(store.get(currentModalIndexAtom)).toBe(0);
     });
 
     it("should handle image loading errors", async () => {
@@ -121,7 +153,7 @@ describe("modal", () => {
       await openModalByIndex(0);
 
       expect(showError).toHaveBeenCalled();
-      expect(state.currentModalIndex).toBe(-1);
+      expect(store.get(currentModalIndexAtom)).toBe(-1);
     });
 
     it("should handle race conditions", async () => {
@@ -140,75 +172,83 @@ describe("modal", () => {
       await promise2;
 
       // Should show image2, not image1 (state-based check)
-      expect(state.currentModalIndex).toBe(1);
+      expect(store.get(currentModalIndexAtom)).toBe(1);
     });
 
     it("should hide shortcuts overlay when opening modal", async () => {
-      state.shortcutsOverlayVisible = true;
-      state.loadedImages.set("/test/image1.png", "data-url");
+      store.set(shortcutsOverlayVisibleAtom, true);
+      const loadedImages = store.get(loadedImagesAtom);
+      const updatedLoadedImages = new Map(loadedImages);
+      updatedLoadedImages.set("/test/image1.png", "data-url");
 
       await openModalByIndex(0);
 
-      expect(state.shortcutsOverlayVisible).toBe(false);
+      expect(store.get(shortcutsOverlayVisibleAtom)).toBe(false);
     });
 
     it("should update modal caption text with image index and filename", async () => {
-      state.loadedImages.set("/test/image1.png", "data-url");
-      state.allImagePaths = [
+      const loadedImages = store.get(loadedImagesAtom);
+      const updatedLoadedImages = new Map(loadedImages);
+      updatedLoadedImages.set("/test/image1.png", "data-url");
+      store.set(allImagePathsAtom, [
         { path: "/test/image1.png" },
         { path: "/test/image2.png" },
-      ];
+      ]);
 
       await openModalByIndex(0);
 
       // React component handles caption rendering - we verify state
-      expect(state.currentModalIndex).toBe(0);
+      expect(store.get(currentModalIndexAtom)).toBe(0);
     });
 
     it("should handle paths with backslashes in modal caption", async () => {
-      state.loadedImages.set("C:\\test\\image1.png", "data-url");
-      state.allImagePaths = [
+      const loadedImages = store.get(loadedImagesAtom);
+      const updatedLoadedImages = new Map(loadedImages);
+      updatedLoadedImages.set("C:\\test\\image1.png", "data-url");
+      store.set(allImagePathsAtom, [
         { path: "C:\\test\\image1.png" },
-      ];
+      ]);
 
       await openModalByIndex(0);
 
       // React component handles caption rendering - we verify state
-      expect(state.currentModalIndex).toBe(0);
+      expect(store.get(currentModalIndexAtom)).toBe(0);
     });
 
     it("should open modal and set currentModalIndex", async () => {
-      state.loadedImages.set("/test/image1.png", "data-url");
+      const loadedImages = store.get(loadedImagesAtom);
+      const updatedLoadedImages = new Map(loadedImages);
+      updatedLoadedImages.set("/test/image1.png", "data-url");
 
       await openModalByIndex(0);
 
-      expect(state.currentModalIndex).toBe(0);
+      expect(store.get(currentModalIndexAtom)).toBe(0);
     });
   });
 
   describe("closeModal", () => {
     it("should hide modal and reset index", () => {
-      state.currentModalIndex = 1;
+      store.set(currentModalIndexAtom, 1);
 
       closeModal();
 
-      expect(state.currentModalIndex).toBe(-1);
+      expect(store.get(currentModalIndexAtom)).toBe(-1);
     });
 
     it("should hide shortcuts overlay", () => {
-      state.shortcutsOverlayVisible = true;
+      store.set(shortcutsOverlayVisibleAtom, true);
 
       closeModal();
 
-      expect(state.shortcutsOverlayVisible).toBe(false);
+      expect(store.get(shortcutsOverlayVisibleAtom)).toBe(false);
     });
   });
 
   describe("showNextImage", () => {
     it("should return early if allImagePaths is not an array", () => {
       const consoleSpy = vi.spyOn(console, "error").mockImplementation(() => {});
-      (state as any).allImagePaths = null;
-      state.currentModalIndex = 0;
+      store.set(allImagePathsAtom, null as any);
+      store.set(currentModalIndexAtom, 0);
 
       showNextImage();
 
@@ -217,86 +257,90 @@ describe("modal", () => {
     });
 
     it("should advance to next image", async () => {
-      state.currentModalImagePath = "/test/image1.png";
-      state.currentModalIndex = 0;
-      state.loadedImages.set("/test/image2.png", "data-url");
+      store.set(currentModalImagePathAtom, "/test/image1.png");
+      store.set(currentModalIndexAtom, 0);
+      const loadedImages = store.get(loadedImagesAtom);
+      const updatedLoadedImages = new Map(loadedImages);
+      updatedLoadedImages.set("/test/image2.png", "data-url");
 
       showNextImage();
       await new Promise((resolve) => setTimeout(resolve, 0));
 
-      expect(state.currentModalIndex).toBe(1);
-      expect(state.currentModalImagePath).toBe("/test/image2.png");
+      expect(store.get(currentModalIndexAtom)).toBe(1);
+      expect(store.get(currentModalImagePathAtom)).toBe("/test/image2.png");
     });
 
     it("should not advance if at last image", () => {
-      state.currentModalImagePath = "/test/image3.png";
-      state.currentModalIndex = 2;
+      store.set(currentModalImagePathAtom, "/test/image3.png");
+      store.set(currentModalIndexAtom, 2);
 
       showNextImage();
 
-      expect(state.currentModalIndex).toBe(2);
-      expect(state.currentModalImagePath).toBe("/test/image3.png");
+      expect(store.get(currentModalIndexAtom)).toBe(2);
+      expect(store.get(currentModalImagePathAtom)).toBe("/test/image3.png");
     });
   });
 
   describe("showPreviousImage", () => {
     it("should go to previous image", async () => {
-      state.currentModalImagePath = "/test/image2.png";
-      state.currentModalIndex = 1;
-      state.loadedImages.set("/test/image1.png", "data-url");
+      store.set(currentModalImagePathAtom, "/test/image2.png");
+      store.set(currentModalIndexAtom, 1);
+      const loadedImages = store.get(loadedImagesAtom);
+      const updatedLoadedImages = new Map(loadedImages);
+      updatedLoadedImages.set("/test/image1.png", "data-url");
 
       showPreviousImage();
       await new Promise((resolve) => setTimeout(resolve, 0));
 
-      expect(state.currentModalIndex).toBe(0);
-      expect(state.currentModalImagePath).toBe("/test/image1.png");
+      expect(store.get(currentModalIndexAtom)).toBe(0);
+      expect(store.get(currentModalImagePathAtom)).toBe("/test/image1.png");
     });
 
     it("should not go back if at first image", () => {
-      state.currentModalImagePath = "/test/image1.png";
-      state.currentModalIndex = 0;
+      store.set(currentModalImagePathAtom, "/test/image1.png");
+      store.set(currentModalIndexAtom, 0);
 
       showPreviousImage();
 
-      expect(state.currentModalIndex).toBe(0);
-      expect(state.currentModalImagePath).toBe("/test/image1.png");
+      expect(store.get(currentModalIndexAtom)).toBe(0);
+      expect(store.get(currentModalImagePathAtom)).toBe("/test/image1.png");
     });
   });
 
 
   describe("toggleShortcutsOverlay", () => {
     it("should toggle overlay visibility", () => {
-      state.shortcutsOverlayVisible = false;
+      store.set(shortcutsOverlayVisibleAtom, false);
 
       toggleShortcutsOverlay();
-      expect(state.shortcutsOverlayVisible).toBe(true);
+      expect(store.get(shortcutsOverlayVisibleAtom)).toBe(true);
 
       toggleShortcutsOverlay();
-      expect(state.shortcutsOverlayVisible).toBe(false);
+      expect(store.get(shortcutsOverlayVisibleAtom)).toBe(false);
     });
 
     it("should return early if overlay is missing", () => {
-      const initialVisible = state.shortcutsOverlayVisible;
+      const initialVisible = store.get(shortcutsOverlayVisibleAtom);
       toggleShortcutsOverlay();
-      expect(state.shortcutsOverlayVisible).toBe(!initialVisible);
+      expect(store.get(shortcutsOverlayVisibleAtom)).toBe(!initialVisible);
     });
   });
 
   describe("deleteCurrentImage", () => {
     it("should return early if allImagePaths is not an array", async () => {
       const consoleSpy = vi.spyOn(console, "error").mockImplementation(() => {});
-      (state as any).allImagePaths = null;
-      state.currentModalIndex = 0;
+      store.set(allImagePathsAtom, null as any);
+      store.set(currentModalIndexAtom, 0);
 
       await deleteCurrentImage();
 
       expect(consoleSpy).toHaveBeenCalled();
-      expect(state.allImagePaths).toEqual([]);
+      expect(store.get(allImagePathsAtom)).toEqual([]);
       consoleSpy.mockRestore();
     });
 
     it("should return early if re-entrancy guard is active", async () => {
-      state.isDeletingImage = true;
+      store.set(isDeletingImageAtom, true);
 
       await deleteCurrentImage();
 
@@ -304,12 +348,12 @@ describe("modal", () => {
     });
 
     it("should return early if index is out of range", async () => {
-      state.currentModalImagePath = "";
-      state.currentModalIndex = -1;
+      store.set(currentModalImagePathAtom, "");
+      store.set(currentModalIndexAtom, -1);
       await deleteCurrentImage();
 
-      state.currentModalImagePath = "";
-      state.currentModalIndex = 100;
+      store.set(currentModalImagePathAtom, "");
+      store.set(currentModalIndexAtom, 100);
       await deleteCurrentImage();
 
       expect(window.__TAURI__!.core.invoke).not.toHaveBeenCalled();
@@ -318,8 +362,20 @@ describe("modal", () => {
     it("should delete image successfully", async () => {
       const tauri = await import("../utils/tauri");
       const { showNotification } = await import("./notification");
-      state.currentModalImagePath = "/test/image2.png";
-      state.currentModalIndex = 1;
+      const { getFilteredAndSortedImagesSync } = await import("../utils/filteredImages");
+      // Mock filtered images - image2 is in the middle
+      vi.mocked(getFilteredAndSortedImagesSync)
+        .mockReturnValueOnce([
+          { path: "/test/image1.png" },
+          { path: "/test/image2.png" },
+          { path: "/test/image3.png" },
+        ])
+        .mockReturnValueOnce([
+          { path: "/test/image1.png" },
+          { path: "/test/image3.png" },
+        ]);
+      store.set(currentModalImagePathAtom, "/test/image2.png");
+      store.set(currentModalIndexAtom, 1);
       vi.spyOn(tauri, "invokeTauri").mockResolvedValueOnce(undefined);
 
       await deleteCurrentImage();
@@ -327,23 +383,29 @@ describe("modal", () => {
       expect(tauri.invokeTauri).toHaveBeenCalledWith("delete_image", {
         imagePath: "/test/image2.png",
       });
-      expect(state.allImagePaths.length).toBe(2);
-      expect(state.allImagePaths.find((img) => img.path === "/test/image2.png")).toBeUndefined();
-      expect(showNotification).toHaveBeenCalledWith("Image deleted");
+      expect(store.get(allImagePathsAtom).length).toBe(2);
+      expect(store.get(allImagePathsAtom).find((img: ImagePath) => img.path === "/test/image2.png")).toBeUndefined();
+      // After deletion, should navigate to next image (image3)
+      expect(showNotification).toHaveBeenCalled();
     });
 
     it("should close modal if only image", async () => {
-      const { invoke } = window.__TAURI__!.core;
+      const tauri = await import("../utils/tauri");
       const { showNotification } = await import("./notification");
-      state.allImagePaths = [{ path: "/test/image1.png" }];
-      state.currentModalImagePath = "/test/image1.png";
-      state.currentModalIndex = 0;
-      vi.mocked(invoke).mockResolvedValueOnce(undefined);
+      const { getFilteredAndSortedImagesSync } = await import("../utils/filteredImages");
+      // Mock filtered images - only one image
+      vi.mocked(getFilteredAndSortedImagesSync)
+        .mockReturnValueOnce([{ path: "/test/image1.png" }]) // Before deletion
+        .mockReturnValueOnce([]); // After deletion - empty
+      store.set(allImagePathsAtom, [{ path: "/test/image1.png" }]);
+      store.set(currentModalImagePathAtom, "/test/image1.png");
+      store.set(currentModalIndexAtom, 0);
+      vi.spyOn(tauri, "invokeTauri").mockResolvedValueOnce(undefined);
 
       await deleteCurrentImage();
 
-      expect(state.currentModalIndex).toBe(-1);
-      expect(state.currentModalImagePath).toBe("");
+      expect(store.get(currentModalIndexAtom)).toBe(-1);
+      expect(store.get(currentModalImagePathAtom)).toBe("");
       expect(showNotification).toHaveBeenCalledWith(
         "Image deleted. No more images in this directory."
       );
@@ -351,42 +413,430 @@ describe("modal", () => {
 
     it("should navigate to previous if last image", async () => {
       const { invoke } = window.__TAURI__!.core;
-      state.currentModalImagePath = "/test/image3.png";
-      state.currentModalIndex = 2;
-      state.loadedImages.set("/test/image2.png", "data-url");
+      const { getFilteredAndSortedImagesSync } = await import("../utils/filteredImages");
+      // Mock filtered images - image3 is last
+      vi.mocked(getFilteredAndSortedImagesSync)
+        .mockReturnValueOnce([
+          { path: "/test/image1.png" },
+          { path: "/test/image2.png" },
+          { path: "/test/image3.png" },
+        ])
+        .mockReturnValueOnce([
+          { path: "/test/image1.png" },
+          { path: "/test/image2.png" },
+        ]);
+      store.set(currentModalImagePathAtom, "/test/image3.png");
+      store.set(currentModalIndexAtom, 2);
+      const loadedImages = store.get(loadedImagesAtom);
+      const updatedLoadedImages = new Map(loadedImages);
+      updatedLoadedImages.set("/test/image2.png", "data-url");
       vi.mocked(invoke).mockResolvedValueOnce(undefined);
 
       await deleteCurrentImage();
 
-      expect(state.currentModalIndex).toBe(1);
-      expect(state.currentModalImagePath).toBe("/test/image2.png");
+      expect(store.get(currentModalIndexAtom)).toBe(1);
+      expect(store.get(currentModalImagePathAtom)).toBe("/test/image2.png");
     });
 
     it("should handle deletion errors", async () => {
-      const { invoke } = window.__TAURI__!.core;
+      const tauri = await import("../utils/tauri");
       const { showError } = await import("./error");
-      state.currentModalImagePath = "/test/image1.png";
-      state.currentModalIndex = 0;
-      vi.mocked(invoke).mockRejectedValueOnce(new Error("Delete failed"));
+      const { getFilteredAndSortedImagesSync } = await import("../utils/filteredImages");
+      vi.mocked(getFilteredAndSortedImagesSync)
+        .mockReturnValueOnce([
+          { path: "/test/image1.png" },
+          { path: "/test/image2.png" },
+        ])
+        .mockReturnValueOnce([
+          { path: "/test/image2.png" },
+        ]);
+      store.set(currentModalImagePathAtom, "/test/image1.png");
+      store.set(currentModalIndexAtom, 0);
+      vi.spyOn(tauri, "invokeTauri").mockRejectedValueOnce(new Error("Delete failed"));
 
       await deleteCurrentImage();
 
-      expect(showError).toHaveBeenCalled();
-      expect(state.isDeletingImage).toBe(false);
+      expect(showError).toHaveBeenCalledWith("Failed to delete image: Error: Delete failed");
+      expect(store.get(isDeletingImageAtom)).toBe(false);
     });
 
     it("should adjust currentIndex when deleting before batch position", async () => {
       const { invoke } = window.__TAURI__!.core;
-      state.currentIndex = 2;
-      state.currentModalImagePath = "/test/image2.png";
-      state.currentModalIndex = 1;
+      store.set(currentIndexAtom, 2);
+      store.set(currentModalImagePathAtom, "/test/image2.png");
+      store.set(currentModalIndexAtom, 1);
       vi.mocked(invoke).mockResolvedValueOnce(undefined);
 
       await deleteCurrentImage();
 
-      expect(state.currentIndex).toBe(1);
+      expect(store.get(currentIndexAtom)).toBe(1);
+    });
+
+    it("should handle deleting image that is not in filtered list", async () => {
+      const { invoke } = window.__TAURI__!.core;
+      const { getFilteredAndSortedImagesSync } = await import("../utils/filteredImages");
+      vi.mocked(getFilteredAndSortedImagesSync).mockReturnValue([
+        { path: "/test/image1.png" },
+        { path: "/test/image3.png" },
+      ]);
+      store.set(currentModalImagePathAtom, "/test/image2.png");
+      store.set(currentModalIndexAtom, 1);
+      vi.mocked(invoke).mockResolvedValueOnce(undefined);
+
+      await deleteCurrentImage();
+
+      // Should still delete from allImagePaths
+      expect(store.get(allImagePathsAtom).length).toBe(2);
+      expect(store.get(allImagePathsAtom).find((img: ImagePath) => img.path === "/test/image2.png")).toBeUndefined();
+    });
+
+    it("should close modal when deleting last image in filtered list", async () => {
+      const { invoke } = window.__TAURI__!.core;
+      const { getFilteredAndSortedImagesSync } = await import("../utils/filteredImages");
+      vi.mocked(getFilteredAndSortedImagesSync).mockReturnValue([
+        { path: "/test/image1.png" },
+      ]);
+      store.set(allImagePathsAtom, [
+        { path: "/test/image1.png" },
+        { path: "/test/image2.png" }, // Not in filtered list
+      ]);
+      store.set(currentModalImagePathAtom, "/test/image1.png");
+      store.set(currentModalIndexAtom, 0);
+      vi.mocked(invoke).mockResolvedValueOnce(undefined);
+
+      await deleteCurrentImage();
+
+      expect(store.get(currentModalIndexAtom)).toBe(-1);
+      expect(store.get(currentModalImagePathAtom)).toBe("");
     });
   });
 
+  describe("openModal with path", () => {
+    beforeEach(async () => {
+      const { getFilteredAndSortedImagesSync } = await import("../utils/filteredImages");
+      vi.mocked(getFilteredAndSortedImagesSync).mockReturnValue([
+        { path: "/test/image1.png" },
+        { path: "/test/image2.png" },
+        { path: "/test/image3.png" },
+      ]);
+    });
+
+    it("should open modal for image in filtered list", async () => {
+      const { getFilteredAndSortedImagesSync } = await import("../utils/filteredImages");
+      const { loadImageData } = await import("../utils/images");
+      const filteredList = [
+        { path: "/test/image1.png" },
+        { path: "/test/image2.png" },
+      ];
+      vi.mocked(getFilteredAndSortedImagesSync).mockReturnValue(filteredList);
+      vi.mocked(loadImageData).mockResolvedValueOnce("data-url");
+
+      await openModal("/test/image2.png");
+
+      expect(loadImageData).toHaveBeenCalledWith("/test/image2.png");
+      expect(store.get(currentModalImagePathAtom)).toBe("/test/image2.png");
+      expect(store.get(currentModalIndexAtom)).toBe(1);
+    });
+
+    it("should not open modal for image not in filtered list", async () => {
+      const { getFilteredAndSortedImagesSync } = await import("../utils/filteredImages");
+      const { loadImageData } = await import("../utils/images");
+      const filteredList = [
+        { path: "/test/image1.png" },
+        { path: "/test/image2.png" },
+      ];
+      // Reset and set up mock specifically for this test
+      vi.mocked(getFilteredAndSortedImagesSync).mockReset();
+      vi.mocked(getFilteredAndSortedImagesSync).mockReturnValue(filteredList);
+      vi.mocked(loadImageData).mockClear();
+
+      await openModal("/test/nonexistent.png");
+
+      expect(loadImageData).not.toHaveBeenCalled();
+      expect(store.get(currentModalImagePathAtom)).toBe("");
+    });
+
+    it("should use cached image data when available", async () => {
+      const { getFilteredAndSortedImagesSync } = await import("../utils/filteredImages");
+      const { loadImageData } = await import("../utils/images");
+      const filteredList = [
+        { path: "/test/image1.png" },
+      ];
+      // Reset and set up mock specifically for this test
+      vi.mocked(getFilteredAndSortedImagesSync).mockReset();
+      vi.mocked(getFilteredAndSortedImagesSync).mockReturnValue(filteredList);
+      vi.mocked(loadImageData).mockClear();
+      const loadedImages = store.get(loadedImagesAtom);
+      const updatedLoadedImages = new Map(loadedImages);
+      updatedLoadedImages.set("/test/image1.png", "cached-data-url");
+      store.set(loadedImagesAtom, updatedLoadedImages);
+
+      await openModal("/test/image1.png");
+
+      expect(loadImageData).not.toHaveBeenCalled();
+      expect(store.get(currentModalImagePathAtom)).toBe("/test/image1.png");
+    });
+
+    it("should handle race condition with multiple openModal calls", async () => {
+      const { getFilteredAndSortedImagesSync } = await import("../utils/filteredImages");
+      const { loadImageData } = await import("../utils/images");
+      vi.mocked(getFilteredAndSortedImagesSync).mockReturnValue([
+        { path: "/test/image1.png" },
+        { path: "/test/image2.png" },
+      ]);
+      
+      let resolveLoad1: (value: string) => void;
+      let resolveLoad2: (value: string) => void;
+      const loadPromise1 = new Promise<string>((resolve) => {
+        resolveLoad1 = resolve;
+      });
+      const loadPromise2 = new Promise<string>((resolve) => {
+        resolveLoad2 = resolve;
+      });
+      vi.mocked(loadImageData)
+        .mockReturnValueOnce(loadPromise1)
+        .mockReturnValueOnce(loadPromise2);
+
+      const promise1 = openModal("/test/image1.png");
+      const promise2 = openModal("/test/image2.png");
+
+      resolveLoad2!("data-url-2");
+      resolveLoad1!("data-url-1");
+      await promise1;
+      await promise2;
+
+      // Should show image2, not image1 (last call wins)
+      expect(store.get(currentModalImagePathAtom)).toBe("/test/image2.png");
+    });
+  });
+
+  describe("showNextImage with suppressCategoryRefilter", () => {
+    beforeEach(async () => {
+      const { getFilteredAndSortedImagesSync } = await import("../utils/filteredImages");
+      vi.mocked(getFilteredAndSortedImagesSync).mockReturnValue([]);
+    });
+
+    it("should clear suppress flag and navigate when image still in filtered list", async () => {
+      const { getFilteredAndSortedImagesSync } = await import("../utils/filteredImages");
+      store.set(suppressCategoryRefilterAtom, true);
+      store.set(cachedImageCategoriesForRefilterAtom, new Map());
+      store.set(currentModalImagePathAtom, "/test/image1.png");
+      vi.mocked(getFilteredAndSortedImagesSync).mockReturnValue([
+        { path: "/test/image1.png" },
+        { path: "/test/image2.png" },
+      ]);
+
+      showNextImage();
+      await new Promise((resolve) => setTimeout(resolve, 0));
+
+      expect(store.get(suppressCategoryRefilterAtom)).toBe(false);
+      expect(store.get(cachedImageCategoriesForRefilterAtom)).toBeNull();
+      expect(store.get(currentModalImagePathAtom)).toBe("/test/image2.png");
+    });
+
+    it("should navigate to first image when current image removed from filtered list", async () => {
+      const { getFilteredAndSortedImagesSync } = await import("../utils/filteredImages");
+      store.set(suppressCategoryRefilterAtom, true);
+      store.set(cachedImageCategoriesForRefilterAtom, new Map());
+      store.set(currentModalImagePathAtom, "/test/image1.png");
+      // Current image not in filtered list anymore
+      vi.mocked(getFilteredAndSortedImagesSync).mockReturnValue([
+        { path: "/test/image2.png" },
+        { path: "/test/image3.png" },
+      ]);
+
+      showNextImage();
+      await new Promise((resolve) => setTimeout(resolve, 0));
+
+      expect(store.get(currentModalImagePathAtom)).toBe("/test/image2.png");
+    });
+
+    it("should not navigate when suppress flag is false and image not in list", async () => {
+      const { getFilteredAndSortedImagesSync } = await import("../utils/filteredImages");
+      store.set(suppressCategoryRefilterAtom, false);
+      store.set(currentModalImagePathAtom, "/test/image1.png");
+      // Current image not in filtered list
+      vi.mocked(getFilteredAndSortedImagesSync).mockReturnValue([
+        { path: "/test/image2.png" },
+      ]);
+
+      showNextImage();
+
+      // Should not navigate when suppress is false
+      expect(store.get(currentModalImagePathAtom)).toBe("/test/image1.png");
+    });
+  });
+
+  describe("showPreviousImage with suppressCategoryRefilter", () => {
+    beforeEach(async () => {
+      const { getFilteredAndSortedImagesSync } = await import("../utils/filteredImages");
+      vi.mocked(getFilteredAndSortedImagesSync).mockReturnValue([]);
+    });
+
+    it("should clear suppress flag and navigate when image still in filtered list", async () => {
+      const { getFilteredAndSortedImagesSync } = await import("../utils/filteredImages");
+      store.set(suppressCategoryRefilterAtom, true);
+      store.set(cachedImageCategoriesForRefilterAtom, new Map());
+      store.set(currentModalImagePathAtom, "/test/image2.png");
+      vi.mocked(getFilteredAndSortedImagesSync).mockReturnValue([
+        { path: "/test/image1.png" },
+        { path: "/test/image2.png" },
+      ]);
+
+      showPreviousImage();
+      await new Promise((resolve) => setTimeout(resolve, 0));
+
+      expect(store.get(suppressCategoryRefilterAtom)).toBe(false);
+      expect(store.get(cachedImageCategoriesForRefilterAtom)).toBeNull();
+      expect(store.get(currentModalImagePathAtom)).toBe("/test/image1.png");
+    });
+
+    it("should navigate to last image when current image removed from filtered list", async () => {
+      const { getFilteredAndSortedImagesSync } = await import("../utils/filteredImages");
+      store.set(suppressCategoryRefilterAtom, true);
+      store.set(cachedImageCategoriesForRefilterAtom, new Map());
+      store.set(currentModalImagePathAtom, "/test/image2.png");
+      // Current image not in filtered list anymore
+      vi.mocked(getFilteredAndSortedImagesSync).mockReturnValue([
+        { path: "/test/image1.png" },
+        { path: "/test/image3.png" },
+      ]);
+
+      showPreviousImage();
+      await new Promise((resolve) => setTimeout(resolve, 0));
+
+      expect(store.get(currentModalImagePathAtom)).toBe("/test/image3.png");
+    });
+  });
+
+  describe("closeModal", () => {
+    it("should clear suppressCategoryRefilter flag", () => {
+      store.set(suppressCategoryRefilterAtom, true);
+      store.set(cachedImageCategoriesForRefilterAtom, new Map());
+
+      closeModal();
+
+      expect(store.get(suppressCategoryRefilterAtom)).toBe(false);
+      expect(store.get(cachedImageCategoriesForRefilterAtom)).toBeNull();
+    });
+
+    it("should reset modal state", () => {
+      store.set(currentModalImagePathAtom, "/test/image1.png");
+      store.set(currentModalIndexAtom, 0);
+
+      closeModal();
+
+      expect(store.get(currentModalImagePathAtom)).toBe("");
+      expect(store.get(currentModalIndexAtom)).toBe(-1);
+    });
+  });
+
+  describe("hideShortcutsOverlay", () => {
+    it("should hide shortcuts overlay", async () => {
+      const { hideShortcutsOverlay } = await import("./modal");
+      store.set(shortcutsOverlayVisibleAtom, true);
+
+      hideShortcutsOverlay();
+
+      expect(store.get(shortcutsOverlayVisibleAtom)).toBe(false);
+    });
+  });
+
+  describe("openModalByIndex edge cases", () => {
+    it("should handle negative index", async () => {
+      await openModalByIndex(-1);
+
+      expect(store.get(currentModalIndexAtom)).toBe(-1);
+      expect(store.get(currentModalImagePathAtom)).toBe("");
+    });
+
+    it("should handle index beyond array length", async () => {
+      await openModalByIndex(100);
+
+      expect(store.get(currentModalIndexAtom)).toBe(-1);
+      expect(store.get(currentModalImagePathAtom)).toBe("");
+    });
+
+    it("should handle empty filtered list", async () => {
+      const { getFilteredAndSortedImagesSync } = await import("../utils/filteredImages");
+      vi.mocked(getFilteredAndSortedImagesSync).mockReturnValue([]);
+
+      await openModalByIndex(0);
+
+      expect(store.get(currentModalIndexAtom)).toBe(-1);
+    });
+  });
+
+  describe("deleteCurrentImage edge cases", () => {
+    it("should handle Tauri API unavailable", async () => {
+      const { isTauriInvokeAvailable } = await import("../utils/tauri");
+      const { showError } = await import("./error");
+      vi.mocked(isTauriInvokeAvailable).mockReturnValue(false);
+      store.set(currentModalImagePathAtom, "/test/image1.png");
+
+      await deleteCurrentImage();
+
+      expect(showError).toHaveBeenCalledWith("Tauri invoke API not available");
+      expect(store.get(isDeletingImageAtom)).toBe(false);
+    });
+
+    it("should handle deleting when image is not in allImagePaths", async () => {
+      const tauri = await import("../utils/tauri");
+      const { getFilteredAndSortedImagesSync } = await import("../utils/filteredImages");
+      // Image2 is in filtered list but not in allImagePaths
+      vi.mocked(getFilteredAndSortedImagesSync)
+        .mockReturnValueOnce([
+          { path: "/test/image1.png" },
+          { path: "/test/image2.png" },
+          { path: "/test/image3.png" },
+        ])
+        .mockReturnValueOnce([
+          { path: "/test/image1.png" },
+          { path: "/test/image3.png" },
+        ]);
+      store.set(allImagePathsAtom, [
+        { path: "/test/image1.png" },
+        { path: "/test/image3.png" },
+      ]);
+      store.set(currentModalImagePathAtom, "/test/image2.png");
+      store.set(currentModalIndexAtom, 1);
+      // Ensure Tauri is available
+      vi.mocked(tauri.isTauriInvokeAvailable).mockReturnValue(true);
+      vi.spyOn(tauri, "invokeTauri").mockResolvedValueOnce(undefined);
+
+      await deleteCurrentImage();
+
+      // Should still attempt deletion, but not remove from array (since it's not in allImagePaths)
+      expect(tauri.invokeTauri).toHaveBeenCalledWith("delete_image", {
+        imagePath: "/test/image2.png",
+      });
+    });
+
+    it("should handle deleting when filtered list becomes empty", async () => {
+      const tauri = await import("../utils/tauri");
+      const { getFilteredAndSortedImagesSync } = await import("../utils/filteredImages");
+      // Reset mock to ensure clean state
+      vi.mocked(getFilteredAndSortedImagesSync).mockReset();
+      // First call: before deletion (to find deletedIndex) - only one image
+      // Second call: after deletion (empty list)
+      vi.mocked(getFilteredAndSortedImagesSync)
+        .mockReturnValueOnce([{ path: "/test/image1.png" }]) // Before deletion - isOnlyImage will be true
+        .mockReturnValueOnce([]); // Empty after deletion
+      store.set(allImagePathsAtom, [{ path: "/test/image1.png" }]);
+      store.set(currentModalImagePathAtom, "/test/image1.png");
+      store.set(currentModalIndexAtom, 0);
+      // Ensure Tauri is available
+      vi.mocked(tauri.isTauriInvokeAvailable).mockReturnValue(true);
+      vi.spyOn(tauri, "invokeTauri").mockResolvedValueOnce(undefined);
+
+      await deleteCurrentImage();
+
+      // Should close modal when filtered list is empty (isOnlyImage is true)
+      // closeModal sets currentModalIndexAtom to -1 and currentModalImagePathAtom to ""
+      // The function returns early after closeModal, so state should be updated
+      expect(store.get(currentModalIndexAtom)).toBe(-1);
+      expect(store.get(currentModalImagePathAtom)).toBe("");
+    });
+  });
 });
 

--- a/src/utils/colors.test.ts
+++ b/src/utils/colors.test.ts
@@ -1,0 +1,212 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { getContrastColor } from "./colors";
+
+describe("getContrastColor", () => {
+  let consoleWarnSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    consoleWarnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    consoleWarnSpy.mockRestore();
+  });
+
+  describe("valid hex colors", () => {
+    it("should accept hex colors with # prefix", () => {
+      expect(getContrastColor("#ff0000")).toBe("#000000");
+      expect(getContrastColor("#00ff00")).toBe("#000000");
+      expect(getContrastColor("#0000ff")).toBe("#ffffff");
+    });
+
+    it("should accept hex colors without # prefix", () => {
+      expect(getContrastColor("ff0000")).toBe("#000000");
+      expect(getContrastColor("00ff00")).toBe("#000000");
+      expect(getContrastColor("0000ff")).toBe("#ffffff");
+    });
+
+    it("should accept uppercase hex colors", () => {
+      expect(getContrastColor("#FF0000")).toBe("#000000");
+      expect(getContrastColor("#00FF00")).toBe("#000000");
+      expect(getContrastColor("#0000FF")).toBe("#ffffff");
+    });
+
+    it("should accept mixed case hex colors", () => {
+      expect(getContrastColor("#Ff0000")).toBe("#000000");
+      expect(getContrastColor("#00Ff00")).toBe("#000000");
+      expect(getContrastColor("#0000Ff")).toBe("#ffffff");
+    });
+
+    it("should return black for light colors", () => {
+      // Light colors have high luminance, so black text has better contrast
+      expect(getContrastColor("#ffffff")).toBe("#000000"); // Pure white
+      expect(getContrastColor("#ffff00")).toBe("#000000"); // Yellow
+      expect(getContrastColor("#ff00ff")).toBe("#000000"); // Magenta
+      expect(getContrastColor("#00ffff")).toBe("#000000"); // Cyan
+      expect(getContrastColor("#cccccc")).toBe("#000000"); // Light gray
+      expect(getContrastColor("#ffcc00")).toBe("#000000"); // Orange
+    });
+
+    it("should return white for dark colors", () => {
+      // Dark colors have low luminance, so white text has better contrast
+      expect(getContrastColor("#000000")).toBe("#ffffff"); // Pure black
+      expect(getContrastColor("#000080")).toBe("#ffffff"); // Navy blue
+      expect(getContrastColor("#800000")).toBe("#ffffff"); // Maroon
+      expect(getContrastColor("#008000")).toBe("#ffffff"); // Dark green
+      expect(getContrastColor("#333333")).toBe("#ffffff"); // Dark gray
+      expect(getContrastColor("#1a1a1a")).toBe("#ffffff"); // Very dark gray
+    });
+
+    it("should handle gray values around the threshold", () => {
+      // Test various gray values to ensure the threshold is calculated correctly
+      expect(getContrastColor("#808080")).toBe("#000000"); // Medium gray (50% gray)
+      expect(getContrastColor("#7f7f7f")).toBe("#000000"); // Slightly lighter than 50%
+      expect(getContrastColor("#808081")).toBe("#000000"); // Slightly lighter than 50%
+    });
+
+    it("should handle primary colors correctly", () => {
+      expect(getContrastColor("#ff0000")).toBe("#000000"); // Red (light)
+      expect(getContrastColor("#00ff00")).toBe("#000000"); // Green (light)
+      expect(getContrastColor("#0000ff")).toBe("#ffffff"); // Blue (dark)
+    });
+
+    it("should handle edge case colors", () => {
+      expect(getContrastColor("#000001")).toBe("#ffffff"); // Almost black
+      expect(getContrastColor("#fffffe")).toBe("#000000"); // Almost white
+      expect(getContrastColor("#010101")).toBe("#ffffff"); // Very dark
+      expect(getContrastColor("#fefefe")).toBe("#000000"); // Very light
+    });
+  });
+
+  describe("invalid hex colors", () => {
+    it("should return black and warn for empty string", () => {
+      const result = getContrastColor("");
+      expect(result).toBe("#000000");
+      expect(consoleWarnSpy).toHaveBeenCalledWith("Invalid hex color: ");
+    });
+
+    it("should return black and warn for invalid format (too short)", () => {
+      const result = getContrastColor("#ff00");
+      expect(result).toBe("#000000");
+      expect(consoleWarnSpy).toHaveBeenCalledWith("Invalid hex color: #ff00");
+    });
+
+    it("should return black and warn for invalid format (too long)", () => {
+      const result = getContrastColor("#ff00000");
+      expect(result).toBe("#000000");
+      expect(consoleWarnSpy).toHaveBeenCalledWith("Invalid hex color: #ff00000");
+    });
+
+    it("should return black and warn for invalid characters", () => {
+      const result = getContrastColor("#gggggg");
+      expect(result).toBe("#000000");
+      expect(consoleWarnSpy).toHaveBeenCalledWith("Invalid hex color: #gggggg");
+    });
+
+    it("should return black and warn for invalid characters (numbers and letters)", () => {
+      const result = getContrastColor("#ff00gg");
+      expect(result).toBe("#000000");
+      expect(consoleWarnSpy).toHaveBeenCalledWith("Invalid hex color: #ff00gg");
+    });
+
+    it("should return black and warn for special characters", () => {
+      const result = getContrastColor("#ff-000");
+      expect(result).toBe("#000000");
+      expect(consoleWarnSpy).toHaveBeenCalledWith("Invalid hex color: #ff-000");
+    });
+
+    it("should return black and warn for non-hex characters", () => {
+      const result = getContrastColor("#xyzabc");
+      expect(result).toBe("#000000");
+      expect(consoleWarnSpy).toHaveBeenCalledWith("Invalid hex color: #xyzabc");
+    });
+
+    it("should return black and warn for invalid format without #", () => {
+      const result = getContrastColor("ff00");
+      expect(result).toBe("#000000");
+      expect(consoleWarnSpy).toHaveBeenCalledWith("Invalid hex color: ff00");
+    });
+
+    it("should return black and warn for string with only #", () => {
+      const result = getContrastColor("#");
+      expect(result).toBe("#000000");
+      expect(consoleWarnSpy).toHaveBeenCalledWith("Invalid hex color: #");
+    });
+
+    it("should return black and warn for 3-character hex (not supported)", () => {
+      const result = getContrastColor("#fff");
+      expect(result).toBe("#000000");
+      expect(consoleWarnSpy).toHaveBeenCalledWith("Invalid hex color: #fff");
+    });
+
+    it("should return black and warn for 8-character hex (with alpha, not supported)", () => {
+      const result = getContrastColor("#ff0000ff");
+      expect(result).toBe("#000000");
+      expect(consoleWarnSpy).toHaveBeenCalledWith("Invalid hex color: #ff0000ff");
+    });
+  });
+
+  describe("WCAG 2.0 formula correctness", () => {
+    it("should calculate correct contrast for pure white", () => {
+      // Pure white (#ffffff) has luminance of 1.0
+      // Contrast with black: (1.0 + 0.05) / (0 + 0.05) = 21.0
+      // Contrast with white: (1.0 + 0.05) / (1.0 + 0.05) = 1.0
+      // Black has better contrast, so should return black
+      expect(getContrastColor("#ffffff")).toBe("#000000");
+    });
+
+    it("should calculate correct contrast for pure black", () => {
+      // Pure black (#000000) has luminance of 0.0
+      // Contrast with black: (0.0 + 0.05) / (0 + 0.05) = 1.0
+      // Contrast with white: (1.0 + 0.05) / (0.0 + 0.05) = 21.0
+      // White has better contrast, so should return white
+      expect(getContrastColor("#000000")).toBe("#ffffff");
+    });
+
+    it("should handle colors with low RGB values (gamma correction path)", () => {
+      // Colors with normalized values <= 0.03928 use the linear path
+      // 0.03928 * 255 = 10.0164, so values <= 10 use linear path
+      expect(getContrastColor("#0a0a0a")).toBe("#ffffff"); // All channels = 10
+      expect(getContrastColor("#050505")).toBe("#ffffff"); // All channels = 5
+    });
+
+    it("should handle colors with high RGB values (gamma correction path)", () => {
+      // Colors with normalized values > 0.03928 use the gamma correction path
+      // 0.03928 * 255 = 10.0164, so values > 10 use gamma path
+      expect(getContrastColor("#0b0b0b")).toBe("#ffffff"); // All channels = 11
+      expect(getContrastColor("#ffffff")).toBe("#000000"); // All channels = 255
+    });
+
+    it("should handle mixed RGB values (some low, some high)", () => {
+      // Test colors where some channels use linear path and some use gamma path
+      expect(getContrastColor("#0aff00")).toBe("#000000"); // R=10 (linear), G=255 (gamma), B=0 (linear)
+      expect(getContrastColor("#ff0a00")).toBe("#000000"); // R=255 (gamma), G=10 (linear), B=0 (linear)
+      expect(getContrastColor("#000aff")).toBe("#ffffff"); // R=0 (linear), G=10 (linear), B=255 (gamma)
+    });
+  });
+
+  describe("real-world color examples", () => {
+    it("should handle common UI colors", () => {
+      // Test various real-world colors to ensure the function works correctly
+      // Note: These assertions are based on actual WCAG calculations
+      expect(getContrastColor("#3b82f6")).toBe("#000000"); // Blue-500 (actually light enough for black)
+      expect(getContrastColor("#10b981")).toBe("#000000"); // Green-500 (light)
+      expect(getContrastColor("#f59e0b")).toBe("#000000"); // Amber-500 (light)
+      expect(getContrastColor("#ef4444")).toBe("#000000"); // Red-500 (light)
+      expect(getContrastColor("#8b5cf6")).toBe("#000000"); // Purple-500 (light)
+      expect(getContrastColor("#1f2937")).toBe("#ffffff"); // Gray-800 (dark)
+      expect(getContrastColor("#f3f4f6")).toBe("#000000"); // Gray-100 (light)
+    });
+
+    it("should handle category colors from the app", () => {
+      // Test some example category colors that might be used
+      expect(getContrastColor("#ff0000")).toBe("#000000"); // Red category
+      expect(getContrastColor("#00ff00")).toBe("#000000"); // Green category
+      expect(getContrastColor("#0000ff")).toBe("#ffffff"); // Blue category
+      expect(getContrastColor("#ffff00")).toBe("#000000"); // Yellow category
+      expect(getContrastColor("#ff00ff")).toBe("#000000"); // Magenta category
+      expect(getContrastColor("#00ffff")).toBe("#000000"); // Cyan category
+    });
+  });
+});
+

--- a/src/utils/colors.ts
+++ b/src/utils/colors.ts
@@ -1,0 +1,48 @@
+/**
+ * Calculate the appropriate contrast color (black or white) for a given hex color
+ * using WCAG 2.0 relative luminance formula with gamma correction.
+ * 
+ * This ensures accessibility compliance with WCAG AA/AAA contrast ratio requirements.
+ * 
+ * @param hexColor - Hex color string (e.g., "#ff0000" or "ff0000")
+ * @returns "#000000" for light colors (better contrast with black) or "#ffffff" for dark colors (better contrast with white)
+ */
+export function getContrastColor(hexColor: string): string {
+  // Remove # if present
+  const hex = hexColor.replace("#", "");
+
+  // Validate hex format
+  if (!/^[0-9A-Fa-f]{6}$/.test(hex)) {
+    console.warn(`Invalid hex color: ${hexColor}`);
+    return "#000000"; // Default to black
+  }
+
+  // Convert to RGB (0-255)
+  const r = parseInt(hex.substring(0, 2), 16);
+  const g = parseInt(hex.substring(2, 4), 16);
+  const b = parseInt(hex.substring(4, 6), 16);
+
+  // Calculate relative luminance with gamma correction (WCAG 2.0 formula)
+  const getRelativeLuminance = (value: number): number => {
+    const normalized = value / 255;
+    return normalized <= 0.03928
+      ? normalized / 12.92
+      : Math.pow((normalized + 0.055) / 1.055, 2.4);
+  };
+
+  const l1 = 0.2126 * getRelativeLuminance(r) + 
+             0.7152 * getRelativeLuminance(g) + 
+             0.0722 * getRelativeLuminance(b);
+
+  // Relative luminances for black and white
+  const blackLuminance = 0; // #000000
+  const whiteLuminance = 1; // #ffffff
+
+  // Calculate contrast ratios (WCAG formula: (L1 + 0.05) / (L2 + 0.05))
+  const contrastWithBlack = (l1 + 0.05) / (blackLuminance + 0.05);
+  const contrastWithWhite = (whiteLuminance + 0.05) / (l1 + 0.05);
+
+  // Return the color with better contrast ratio
+  return contrastWithBlack > contrastWithWhite ? "#000000" : "#ffffff";
+}
+

--- a/src/utils/images.test.ts
+++ b/src/utils/images.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { createPlaceholder, createErrorPlaceholder, createImageElement, loadImageData } from './images';
-import { state } from '../state';
+import { store } from './jotaiStore';
+import { allImagePathsAtom, loadedImagesAtom, currentModalImagePathAtom, resetStateAtom } from '../state';
 
 // Mock the modal module
 vi.mock('../ui/modal', () => ({
@@ -10,7 +11,8 @@ vi.mock('../ui/modal', () => ({
 describe('image utilities', () => {
   beforeEach(() => {
     // Reset state
-    state.allImagePaths = [];
+    store.set(resetStateAtom);
+    store.set(allImagePathsAtom, []);
     vi.clearAllMocks();
   });
 
@@ -45,7 +47,7 @@ describe('image utilities', () => {
       const imagePath = '/path/to/image.jpg';
       const dataUrl = 'data:image/jpeg;base64,testdata';
       
-      state.allImagePaths = [{ path: imagePath }];
+      store.set(allImagePathsAtom, [{ path: imagePath }]);
 
       const img = createImageElement(imagePath, dataUrl);
 
@@ -59,7 +61,7 @@ describe('image utilities', () => {
       const imagePath = '/Users/iomz/Pictures/photo.png';
       const dataUrl = 'data:image/png;base64,test';
       
-      state.allImagePaths = [{ path: imagePath }];
+      store.set(allImagePathsAtom, [{ path: imagePath }]);
 
       const img = createImageElement(imagePath, dataUrl);
       expect(img.alt).toBe('photo.png');
@@ -69,7 +71,7 @@ describe('image utilities', () => {
       const imagePath = 'C:\\Users\\iomz\\Pictures\\photo.png';
       const dataUrl = 'data:image/png;base64,test';
       
-      state.allImagePaths = [{ path: imagePath }];
+      store.set(allImagePathsAtom, [{ path: imagePath }]);
 
       const img = createImageElement(imagePath, dataUrl);
       expect(img.alt).toBe('photo.png');
@@ -79,7 +81,7 @@ describe('image utilities', () => {
       const imagePath = 'image';
       const dataUrl = 'data:image/jpeg;base64,test';
       
-      state.allImagePaths = [{ path: imagePath }];
+      store.set(allImagePathsAtom, [{ path: imagePath }]);
 
       const img = createImageElement(imagePath, dataUrl);
       expect(img.alt).toBe('image');
@@ -89,7 +91,7 @@ describe('image utilities', () => {
       const imagePath = '/path/to/image.jpg';
       const dataUrl = 'data:image/jpeg;base64,test';
       
-      state.allImagePaths = [{ path: imagePath }];
+      store.set(allImagePathsAtom, [{ path: imagePath }]);
 
       const img = createImageElement(imagePath, dataUrl);
       
@@ -106,7 +108,7 @@ describe('image utilities', () => {
 
     it('should return early if allImagePaths is not an array', () => {
       const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
-      (state as any).allImagePaths = null;
+      store.set(allImagePathsAtom, null as any);
       const imagePath = '/path/to/image.jpg';
       const dataUrl = 'data:image/jpeg;base64,test';
 
@@ -121,8 +123,8 @@ describe('image utilities', () => {
 
     it('should not open modal if image not found in allImagePaths', async () => {
       const { openModal } = await import('../ui/modal');
-      state.allImagePaths = [{ path: '/other/image.jpg' }];
-      state.currentModalImagePath = "";
+      store.set(allImagePathsAtom, [{ path: '/other/image.jpg' }]);
+      store.set(currentModalImagePathAtom, "");
       const imagePath = '/path/to/image.jpg';
       const dataUrl = 'data:image/jpeg;base64,test';
 
@@ -133,7 +135,7 @@ describe('image utilities', () => {
 
       // openModal is called but returns early because image is not in filtered list
       // Check that modal state wasn't changed
-      expect(state.currentModalImagePath).toBe("");
+      expect(store.get(currentModalImagePathAtom)).toBe("");
     });
   });
 
@@ -144,7 +146,7 @@ describe('image utilities', () => {
           invoke: vi.fn(),
         },
       };
-      state.loadedImages.clear();
+      store.set(loadedImagesAtom, new Map());
     });
 
     it('should load image data successfully', async () => {
@@ -156,7 +158,7 @@ describe('image utilities', () => {
 
       expect(invoke).toHaveBeenCalledWith('load_image', { imagePath: '/test/image.png' });
       expect(result).toBe(dataUrl);
-      expect(state.loadedImages.get('/test/image.png')).toBe(dataUrl);
+      expect(store.get(loadedImagesAtom).get('/test/image.png')).toBe(dataUrl);
     });
 
     it('should throw error when Tauri API is unavailable', async () => {
@@ -198,7 +200,7 @@ describe('image utilities', () => {
       expect(invoke).toHaveBeenCalledTimes(2);
       expect(result1).toBe(dataUrl);
       expect(result2).toBe(dataUrl);
-      expect(state.loadedImages.get('/test/image.png')).toBe(dataUrl);
+      expect(store.get(loadedImagesAtom).get('/test/image.png')).toBe(dataUrl);
     });
   });
 });

--- a/src/utils/images.ts
+++ b/src/utils/images.ts
@@ -1,4 +1,5 @@
-import { state } from "../state";
+import { store } from "./jotaiStore";
+import { loadedImagesAtom } from "../state";
 import { createElement } from "./dom";
 import { openModal } from "../ui/modal";
 import { ensureImagePathsArray, getFilename } from "./state";
@@ -17,7 +18,10 @@ export async function loadImageData(imagePath: string): Promise<string> {
     if (!dataUrl || typeof dataUrl !== 'string') {
       throw new Error(`Invalid data URL returned for ${imagePath}`);
     }
-    state.loadedImages.set(imagePath, dataUrl);
+    const loadedImages = store.get(loadedImagesAtom);
+    const updatedLoadedImages = new Map(loadedImages);
+    updatedLoadedImages.set(imagePath, dataUrl);
+    store.set(loadedImagesAtom, updatedLoadedImages);
     return dataUrl;
   } catch (error) {
     throw new Error(`Failed to load image: ${error}`);

--- a/src/utils/images.ts
+++ b/src/utils/images.ts
@@ -1,4 +1,4 @@
-import { store } from "./jotaiStore";
+import { updateAtomMap } from "./jotaiStore";
 import { loadedImagesAtom } from "../state";
 import { createElement } from "./dom";
 import { openModal } from "../ui/modal";
@@ -18,10 +18,7 @@ export async function loadImageData(imagePath: string): Promise<string> {
     if (!dataUrl || typeof dataUrl !== 'string') {
       throw new Error(`Invalid data URL returned for ${imagePath}`);
     }
-    const loadedImages = store.get(loadedImagesAtom);
-    const updatedLoadedImages = new Map(loadedImages);
-    updatedLoadedImages.set(imagePath, dataUrl);
-    store.set(loadedImagesAtom, updatedLoadedImages);
+    updateAtomMap(loadedImagesAtom, imagePath, dataUrl);
     return dataUrl;
   } catch (error) {
     throw new Error(`Failed to load image: ${error}`);

--- a/src/utils/jotaiStore.test.ts
+++ b/src/utils/jotaiStore.test.ts
@@ -1,0 +1,116 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { store, updateAtomMap, deleteFromAtomMap } from "./jotaiStore";
+import { loadedImagesAtom, imageCategoriesAtom } from "../state";
+
+describe("jotaiStore helpers", () => {
+  beforeEach(() => {
+    // Reset atoms before each test
+    store.set(loadedImagesAtom, new Map());
+    store.set(imageCategoriesAtom, new Map());
+  });
+
+  describe("updateAtomMap", () => {
+    it("should update a Map atom with a new key-value pair", () => {
+      const initialMap = new Map([["key1", "value1"]]);
+      store.set(loadedImagesAtom, initialMap);
+
+      updateAtomMap(loadedImagesAtom, "key2", "value2");
+
+      const updatedMap = store.get(loadedImagesAtom);
+      expect(updatedMap.get("key1")).toBe("value1");
+      expect(updatedMap.get("key2")).toBe("value2");
+      expect(updatedMap.size).toBe(2);
+      // Should be a new Map instance (immutability)
+      expect(updatedMap).not.toBe(initialMap);
+    });
+
+    it("should overwrite existing key-value pair", () => {
+      const initialMap = new Map([["key1", "value1"]]);
+      store.set(loadedImagesAtom, initialMap);
+
+      updateAtomMap(loadedImagesAtom, "key1", "updated_value");
+
+      const updatedMap = store.get(loadedImagesAtom);
+      expect(updatedMap.get("key1")).toBe("updated_value");
+      expect(updatedMap.size).toBe(1);
+    });
+
+    it("should work with empty Map", () => {
+      store.set(loadedImagesAtom, new Map());
+
+      updateAtomMap(loadedImagesAtom, "key1", "value1");
+
+      const updatedMap = store.get(loadedImagesAtom);
+      expect(updatedMap.get("key1")).toBe("value1");
+      expect(updatedMap.size).toBe(1);
+    });
+
+    it("should work with different Map types", () => {
+      const initialMap = new Map([["/image1.jpg", [{ category_id: "cat1", assigned_at: "2024-01-01" }]]]);
+      store.set(imageCategoriesAtom, initialMap);
+
+      const newAssignments = [{ category_id: "cat2", assigned_at: "2024-01-02" }];
+      updateAtomMap(imageCategoriesAtom, "/image2.jpg", newAssignments);
+
+      const updatedMap = store.get(imageCategoriesAtom);
+      expect(updatedMap.get("/image1.jpg")).toEqual([{ category_id: "cat1", assigned_at: "2024-01-01" }]);
+      expect(updatedMap.get("/image2.jpg")).toEqual(newAssignments);
+      expect(updatedMap.size).toBe(2);
+    });
+  });
+
+  describe("deleteFromAtomMap", () => {
+    it("should delete a key from a Map atom", () => {
+      const initialMap = new Map([
+        ["key1", "value1"],
+        ["key2", "value2"],
+      ]);
+      store.set(loadedImagesAtom, initialMap);
+
+      deleteFromAtomMap(loadedImagesAtom, "key1");
+
+      const updatedMap = store.get(loadedImagesAtom);
+      expect(updatedMap.has("key1")).toBe(false);
+      expect(updatedMap.get("key2")).toBe("value2");
+      expect(updatedMap.size).toBe(1);
+      // Should be a new Map instance (immutability)
+      expect(updatedMap).not.toBe(initialMap);
+    });
+
+    it("should handle deleting non-existent key gracefully", () => {
+      const initialMap = new Map([["key1", "value1"]]);
+      store.set(loadedImagesAtom, initialMap);
+
+      deleteFromAtomMap(loadedImagesAtom, "nonexistent");
+
+      const updatedMap = store.get(loadedImagesAtom);
+      expect(updatedMap.get("key1")).toBe("value1");
+      expect(updatedMap.size).toBe(1);
+    });
+
+    it("should work with empty Map", () => {
+      store.set(loadedImagesAtom, new Map());
+
+      deleteFromAtomMap(loadedImagesAtom, "key1");
+
+      const updatedMap = store.get(loadedImagesAtom);
+      expect(updatedMap.size).toBe(0);
+    });
+
+    it("should work with different Map types", () => {
+      const initialMap = new Map([
+        ["/image1.jpg", [{ category_id: "cat1", assigned_at: "2024-01-01" }]],
+        ["/image2.jpg", [{ category_id: "cat2", assigned_at: "2024-01-02" }]],
+      ]);
+      store.set(imageCategoriesAtom, initialMap);
+
+      deleteFromAtomMap(imageCategoriesAtom, "/image1.jpg");
+
+      const updatedMap = store.get(imageCategoriesAtom);
+      expect(updatedMap.has("/image1.jpg")).toBe(false);
+      expect(updatedMap.get("/image2.jpg")).toEqual([{ category_id: "cat2", assigned_at: "2024-01-02" }]);
+      expect(updatedMap.size).toBe(1);
+    });
+  });
+});
+

--- a/src/utils/jotaiStore.ts
+++ b/src/utils/jotaiStore.ts
@@ -1,6 +1,47 @@
 import { getDefaultStore } from "jotai";
+import type { WritableAtom } from "jotai";
 
 // Export a default store instance for use outside React components
 // This allows utility functions, handlers, and other non-React code to access and update atoms
 export const store = getDefaultStore();
+
+/**
+ * Helper function to update a Map atom with a new key-value pair.
+ * 
+ * This abstracts the read-clone-modify-write pattern for Map updates,
+ * ensuring immutability and reducing boilerplate code.
+ * 
+ * @param atom - The Jotai atom containing a Map
+ * @param key - The key to set in the Map
+ * @param value - The value to set for the key
+ */
+export function updateAtomMap<K, V>(
+  atom: WritableAtom<Map<K, V>, [Map<K, V>], void>,
+  key: K,
+  value: V
+): void {
+  const current = store.get(atom);
+  const updated = new Map(current);
+  updated.set(key, value);
+  store.set(atom, updated);
+}
+
+/**
+ * Helper function to delete a key from a Map atom.
+ * 
+ * This abstracts the read-clone-modify-write pattern for Map deletions,
+ * ensuring immutability and reducing boilerplate code.
+ * 
+ * @param atom - The Jotai atom containing a Map
+ * @param key - The key to delete from the Map
+ */
+export function deleteFromAtomMap<K, V>(
+  atom: WritableAtom<Map<K, V>, [Map<K, V>], void>,
+  key: K
+): void {
+  const current = store.get(atom);
+  const updated = new Map(current);
+  updated.delete(key);
+  store.set(atom, updated);
+}
 

--- a/src/utils/jotaiStore.ts
+++ b/src/utils/jotaiStore.ts
@@ -1,0 +1,6 @@
+import { getDefaultStore } from "jotai";
+
+// Export a default store instance for use outside React components
+// This allows utility functions, handlers, and other non-React code to access and update atoms
+export const store = getDefaultStore();
+

--- a/src/utils/state.test.ts
+++ b/src/utils/state.test.ts
@@ -1,0 +1,143 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { store } from "./jotaiStore";
+import { allImagePathsAtom, resetStateAtom } from "../state";
+import { ensureImagePathsArray, normalizePath, getFilename } from "./state";
+
+describe("state utilities", () => {
+  beforeEach(() => {
+    store.set(resetStateAtom);
+  });
+
+  describe("ensureImagePathsArray", () => {
+    it("should return true when allImagePathsAtom is a valid array", () => {
+      store.set(allImagePathsAtom, [{ path: "/test/image1.jpg" }]);
+
+      const result = ensureImagePathsArray("testContext");
+
+      expect(result).toBe(true);
+      expect(store.get(allImagePathsAtom)).toEqual([{ path: "/test/image1.jpg" }]);
+    });
+
+    it("should return true when allImagePathsAtom is an empty array", () => {
+      store.set(allImagePathsAtom, []);
+
+      const result = ensureImagePathsArray("testContext");
+
+      expect(result).toBe(true);
+      expect(store.get(allImagePathsAtom)).toEqual([]);
+    });
+
+    it("should reset and return false when allImagePathsAtom is not an array", () => {
+      const consoleSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+      store.set(allImagePathsAtom, "not an array" as any);
+
+      const result = ensureImagePathsArray("testContext");
+
+      expect(result).toBe(false);
+      expect(store.get(allImagePathsAtom)).toEqual([]);
+      expect(consoleSpy).toHaveBeenCalledWith(
+        "allImagePathsAtom is not an array in testContext:",
+        "not an array"
+      );
+      consoleSpy.mockRestore();
+    });
+
+    it("should reset and return false when allImagePathsAtom is null", () => {
+      const consoleSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+      store.set(allImagePathsAtom, null as any);
+
+      const result = ensureImagePathsArray("testContext");
+
+      expect(result).toBe(false);
+      expect(store.get(allImagePathsAtom)).toEqual([]);
+      expect(consoleSpy).toHaveBeenCalled();
+      consoleSpy.mockRestore();
+    });
+
+    it("should reset and return false when allImagePathsAtom is undefined", () => {
+      const consoleSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+      store.set(allImagePathsAtom, undefined as any);
+
+      const result = ensureImagePathsArray("testContext");
+
+      expect(result).toBe(false);
+      expect(store.get(allImagePathsAtom)).toEqual([]);
+      expect(consoleSpy).toHaveBeenCalled();
+      consoleSpy.mockRestore();
+    });
+  });
+
+  describe("normalizePath", () => {
+    it("should convert backslashes to forward slashes", () => {
+      expect(normalizePath("C:\\Users\\test\\image.jpg")).toBe("C:/Users/test/image.jpg");
+      expect(normalizePath("path\\to\\file")).toBe("path/to/file");
+    });
+
+    it("should leave forward slashes unchanged", () => {
+      expect(normalizePath("/path/to/file")).toBe("/path/to/file");
+      expect(normalizePath("path/to/file")).toBe("path/to/file");
+    });
+
+    it("should handle mixed slashes", () => {
+      expect(normalizePath("C:\\Users/test\\image.jpg")).toBe("C:/Users/test/image.jpg");
+    });
+
+    it("should handle paths with no slashes", () => {
+      expect(normalizePath("filename.jpg")).toBe("filename.jpg");
+    });
+
+    it("should handle empty string", () => {
+      expect(normalizePath("")).toBe("");
+    });
+
+    it("should handle multiple consecutive backslashes", () => {
+      expect(normalizePath("C:\\\\Users\\\\test")).toBe("C://Users//test");
+    });
+  });
+
+  describe("getFilename", () => {
+    it("should extract filename from Unix-style path", () => {
+      expect(getFilename("/path/to/image.jpg")).toBe("image.jpg");
+      expect(getFilename("/home/user/photos/picture.png")).toBe("picture.png");
+    });
+
+    it("should extract filename from Windows-style path", () => {
+      expect(getFilename("C:\\Users\\test\\image.jpg")).toBe("image.jpg");
+      expect(getFilename("C:\\Program Files\\app\\file.txt")).toBe("file.txt");
+    });
+
+    it("should extract filename from path with no directory", () => {
+      expect(getFilename("image.jpg")).toBe("image.jpg");
+      expect(getFilename("file.txt")).toBe("file.txt");
+    });
+
+    it("should handle path ending with slash", () => {
+      // split("/").pop() returns empty string for paths ending with /
+      // Since "" is falsy, || path fallback returns the original path (not normalized)
+      expect(getFilename("/path/to/")).toBe("/path/to/");
+      expect(getFilename("C:\\Users\\")).toBe("C:\\Users\\");
+    });
+
+    it("should handle root path", () => {
+      // For "/", split("/") returns ["", ""], pop() returns "", but || path returns "/"
+      // Actually, split("/").pop() on "/" returns "" (the last element), so || path fallback doesn't trigger
+      // But the function returns path if pop() is falsy, so "/" returns "/"
+      expect(getFilename("/")).toBe("/");
+    });
+
+    it("should return original path if extraction fails", () => {
+      // This shouldn't happen in practice, but test the fallback
+      expect(getFilename("")).toBe("");
+    });
+
+    it("should handle paths with special characters", () => {
+      expect(getFilename("/path/to/file with spaces.jpg")).toBe("file with spaces.jpg");
+      expect(getFilename("/path/to/file-name_123.jpg")).toBe("file-name_123.jpg");
+    });
+
+    it("should handle mixed path separators", () => {
+      expect(getFilename("C:\\Users/test\\image.jpg")).toBe("image.jpg");
+    });
+  });
+});
+

--- a/src/utils/state.ts
+++ b/src/utils/state.ts
@@ -1,15 +1,17 @@
-import { state } from "../state";
+import { store } from "./jotaiStore";
+import { allImagePathsAtom } from "../state";
 
 /**
- * Ensures state.allImagePaths is a valid array, resetting it if necessary.
+ * Ensures allImagePathsAtom is a valid array, resetting it if necessary.
  * 
  * @param context - Context string for error logging (e.g., function name)
  * @returns true if allImagePaths is valid, false otherwise
  */
 export function ensureImagePathsArray(context: string): boolean {
-  if (!Array.isArray(state.allImagePaths)) {
-    console.error(`state.allImagePaths is not an array in ${context}:`, state.allImagePaths);
-    state.allImagePaths = [];
+  const allImagePaths = store.get(allImagePathsAtom);
+  if (!Array.isArray(allImagePaths)) {
+    console.error(`allImagePathsAtom is not an array in ${context}:`, allImagePaths);
+    store.set(allImagePathsAtom, []);
     return false;
   }
   return true;


### PR DESCRIPTION
- Migrate from previous state management to Jotai atoms
- Add new jotaiStore utility for centralized store management
- Update all components and handlers to use Jotai atoms
- Improve test coverage for dragDrop.ts (34 new test cases)
  - extractPathsFromEvent: empty arrays, special characters, Windows paths, very long arrays
  - handleFileDrop: empty paths, multiple paths, Windows paths, unicode, concurrent drops
  - setupDocumentDragHandlers: missing drop zone, null targets, multiple cleanup calls
  - setupTauriDragEvents: undefined unlisten, all registrations failing, multiple DROP events
  - selectFolder: multiple folders, empty strings, non-string returns, various error types
- Fix flaky test in categories.test.ts
  - Replace strict timestamp uniqueness requirement with non-decreasing validation
  - Increase delay from 1ms to 2ms for better reliability
  - Allow for duplicate timestamps in rapid operations (realistic behavior)

All tests passing consistently (70 tests in dragDrop.test.ts, 110 in categories.test.ts)

This PR resolves #20 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Migrated to a reactive atom-based state store for snappier, more consistent UI updates across dialogs, grids, modals, and sidebars.
* **Bug Fixes**
  * More robust drag‑and‑drop, folder selection, and loading error handling to reduce race conditions and stale UI states.
* **New Features**
  * Improved color-contrast selection for category tags for better readability.
* **Tests**
  * Expanded test coverage and edge-case scenarios to increase reliability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->