### PR TITLE
feat(ui): add category badges to image grid and fix modal index mismatch

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-![hito-app-icon](https://i.imgur.com/BAqSxE0.png)
-
 # Hito
+
+![hito-app-icon](https://i.imgur.com/BAqSxE0.png)
 
 [![release](https://github.com/iomz/hito/actions/workflows/release.yml/badge.svg?branch=release)](https://github.com/iomz/hito/actions/workflows/release.yml)
 [![codecov](https://codecov.io/gh/iomz/hito/graph/badge.svg?token=JUh7WEGnQe)](https://codecov.io/gh/iomz/hito)
@@ -14,22 +14,27 @@ Simply drag and drop a folder to start browsing your images.
 
 ## Features
 
+![demo](https://github.com/user-attachments/assets/6be51dd4-19e8-42f1-b5e8-a574458f3894)
+
 ### Image Browsing
 
 - **Drag & Drop**: Drag folders directly into the app to browse images
 - **Lazy Loading**: Images load on-demand with infinite scroll for smooth performance
 - **Image Carousel**: Click any image to open a full-screen modal with navigation
-- **Breadcrumb Navigation**: Click on path segments to navigate to parent directories
-- **Image Statistics**: View total image count and current directory information
+- **Breadcrumb Navigation**: Click on path segments to navigate to parent directories. The breadcrumb appears next to the logo in the header when browsing a folder
+- **Image Statistics**: View total image count and categorized image count in the header, displayed alongside sort/filter controls
 
 ### Image Organization
 
 - **Category Management**: Create, edit, and delete custom categories with color coding
 - **Category Assignment**: Assign multiple categories to images for flexible organization
-- **Category Filtering**: Filter images by category or view uncategorized images
-- **Name Filtering**: Filter images by filename with operators (contains, starts with, ends with, exact match)
-- **Size Filtering**: Filter images by file size with operators (larger than, less than, or between two values). Size values are specified in KB.
-- **Sorting**: Sort images by name, creation date, last categorized date, or file size
+- **Badge-Based Filtering & Sorting**: Clean, minimal UI showing only active filters and sorts as badges
+  - **Category Filtering**: Filter images by category or view uncategorized images
+  - **Name Filtering**: Filter images by filename with operators (contains, starts with, ends with, exact match)
+  - **Size Filtering**: Filter images by file size with operators (larger than, less than, or between two values). Size values are specified in KB.
+  - **Sorting**: Sort images by name, creation date, last categorized date, or file size
+  - Click the "+" button to add new sort/filter options
+  - Click any badge to edit, or use the × button to remove
 - **Data File Management**: Customize the data file path (`.hito.json`) per directory for flexible storage
 
 ### Keyboard Shortcuts
@@ -116,24 +121,28 @@ Download the installer from [the latest release](https://github.com/iomz/hito/re
 
 ### Organizing Images
 
-1. **Open sidebar**: Click the hamburger menu (☰) button when viewing a directory
+1. **Open sidebar**: Click the hamburger menu (☰) button in the top-right corner when viewing a directory. The sidebar slides in from the right.
 2. **Create categories**: Go to the "Categories" tab and click "+ Add" to create a new category
 3. **Assign categories**:
    - In the modal view, click category buttons to assign/unassign categories to the current image
    - Categories are saved automatically to the data file (`.hito.json`)
-4. **Filter images**: Use the filter controls in the header to filter by category, name, or size. For size filtering, select an operator (larger than, less than, or between) and enter the size value(s) in KB. When using "between", enter both the minimum and maximum values.
-5. **Sort images**: Use the sort dropdown to sort images by various criteria
+4. **Filter and sort images**: Use the badge-based filter/sort system in the header:
+   - Click the "+" button to add a new sort or filter (category, name, or size)
+   - Active filters and sorts appear as badges in the header
+   - Click any badge to edit it, or click the × button to remove it
+   - For size filtering, select an operator (larger than, less than, or between) and enter the size value(s) in KB. When using "between", enter both the minimum and maximum values.
+   - Image statistics (total count and categorized count) are displayed on the right side of the header
 
 ### Customizing Hotkeys
 
-1. **Open sidebar**: Click the hamburger menu (☰) button
+1. **Open sidebar**: Click the hamburger menu (☰) button in the top-right corner
 2. **Go to Hotkeys tab**: Click the "Hotkeys" tab in the sidebar
 3. **Add hotkey**: Click "+ Add Hotkey" to create a new keyboard shortcut
 4. **Configure**: Set the key combination and action for your hotkey
 
 ### Data File Management
 
-1. **Open sidebar**: Click the hamburger menu (☰) button
+1. **Open sidebar**: Click the hamburger menu (☰) button in the top-right corner
 2. **Go to File tab**: Click the "File" tab in the sidebar
 3. **Set custom path**: Enter a custom path for the data file (`.hito.json`) for the current directory
 4. **Save**: Click "Save" to persist the custom data file path for this directory

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -86,11 +86,13 @@ function App() {
       <NotificationBar />
       <HotkeySidebar />
       <main className="container">
-        <Logo />
+        <div className={`app-header ${hasContent ? "has-content" : ""}`}>
+          <Logo />
+          {hasContent && <CurrentPath id="current-path-header" />}
+        </div>
         <div className={`path-input-container ${hasContent && !isDragOver ? "collapsed" : ""}`}>
           <DropZone />
-          <CurrentPath />
-          <ImageGridStats />
+          {!hasContent && <CurrentPath id="current-path-dropzone" />}
           <ErrorMessage />
         </div>
         {/* Conditionally render ImageGrid when content is available */}

--- a/src/components/CurrentPath.tsx
+++ b/src/components/CurrentPath.tsx
@@ -4,14 +4,16 @@ import { currentDirectoryAtom } from "../state";
 import { normalizePath } from "../utils/state";
 import { handleFolder } from "../handlers/dragDrop";
 
-export function CurrentPath() {
+interface CurrentPathProps {
+  id?: string;
+}
+
+export function CurrentPath({ id = "current-path" }: CurrentPathProps = {}) {
   const currentDirectory = useAtomValue(currentDirectoryAtom);
   const isVisible = useMemo(() => currentDirectory.length > 0, [currentDirectory]);
 
   if (!isVisible || !currentDirectory) {
-    return (
-      <div id="current-path" className="current-path" style={{ display: "none" }}></div>
-    );
+    return null;
   }
 
   const normalized = normalizePath(currentDirectory);
@@ -46,7 +48,7 @@ export function CurrentPath() {
   });
 
   return (
-    <div id="current-path" className="current-path" style={{ display: "block" }}>
+    <div id={id} className="current-path">
       <nav className="breadcrumb">
         {breadcrumbItems.map((item, index) => (
           <React.Fragment key={index}>

--- a/src/components/ImageGrid.tsx
+++ b/src/components/ImageGrid.tsx
@@ -12,6 +12,7 @@ import {
   suppressCategoryRefilterAtom,
   cachedImageCategoriesForRefilterAtom,
   isLoadingAtom,
+  sortedImagesAtom,
 } from "../state";
 import { store } from "../utils/jotaiStore";
 import { BATCH_SIZE } from "../constants";
@@ -44,6 +45,7 @@ export function ImageGrid() {
   const isLoadingBatch = useAtomValue(isLoadingBatchAtom);
   const setCurrentIndex = useSetAtom(currentIndexAtom);
   const setIsLoading = useSetAtom(isLoadingAtom);
+  const setSortedImagesAtom = useSetAtom(sortedImagesAtom);
   
   // Initialize from atoms to avoid missing initial images
   const [visibleCount, setVisibleCount] = useState(() => {
@@ -93,6 +95,7 @@ export function ImageGrid() {
       setVisibleCount(0);
       setDirCount(0);
       setSortedImages([]);
+      setSortedImagesAtom([]);
       setSortedDirectories([]);
     }
   }, [allImagePaths, visibleCount]);
@@ -157,6 +160,7 @@ export function ImageGrid() {
         const sorted = await getFilteredAndSortedImages();
         if (!cancelled) {
           setSortedImages(sorted);
+          setSortedImagesAtom(sorted);
           setIsLoading(false);
         }
         return;
@@ -165,6 +169,7 @@ export function ImageGrid() {
       if (images.length === 0) {
         if (!cancelled) {
           setSortedImages([]);
+          setSortedImagesAtom([]);
           setIsLoading(false);
         }
         return;
@@ -204,6 +209,7 @@ export function ImageGrid() {
 
         if (!cancelled) {
           setSortedImages(sorted);
+          setSortedImagesAtom(sorted);
         }
       } catch (error) {
         console.error("Failed to sort images in Rust:", error);
@@ -211,6 +217,7 @@ export function ImageGrid() {
         const sorted = await getFilteredAndSortedImages();
         if (!cancelled) {
           setSortedImages(sorted);
+          setSortedImagesAtom(sorted);
         }
       } finally {
         // Hide loading spinner after sorting completes, but only if this is still the current operation
@@ -230,7 +237,7 @@ export function ImageGrid() {
         setIsLoading(false);
       }
     };
-  }, [allImagePaths, sortOption, sortDirection, sortFilterKey, imageCategories, suppressCategoryRefilter, cachedImageCategoriesForRefilter, setIsLoading]);
+  }, [allImagePaths, sortOption, sortDirection, sortFilterKey, imageCategories, suppressCategoryRefilter, cachedImageCategoriesForRefilter, setIsLoading, setSortedImagesAtom]);
 
   // Filtering is now done in Rust, so sortedImages are already filtered
   const processedImages = React.useMemo(() => {

--- a/src/components/ImageGridHeader.tsx
+++ b/src/components/ImageGridHeader.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import { ImageGridSelection } from "./ImageGridSelection";
 import { ImageGridSortFilter } from "./ImageGridSortFilter";
+import { ImageGridStats } from "./ImageGridStats";
 
 export function ImageGridHeader() {
   return (
@@ -8,6 +9,7 @@ export function ImageGridHeader() {
       <ImageGridSelection />
       <div className="image-grid-header-row">
         <ImageGridSortFilter />
+        <ImageGridStats />
       </div>
     </div>
   );

--- a/src/components/ImageGridSortFilter.tsx
+++ b/src/components/ImageGridSortFilter.tsx
@@ -1,10 +1,12 @@
 import React, { useEffect, useState, useCallback, useRef } from "react";
 import { useAtomValue, useSetAtom } from "jotai";
 import { sortOptionAtom, sortDirectionAtom, filterOptionsAtom, categoriesAtom } from "../state";
+import { Tooltip, TooltipContent, TooltipTrigger } from "./ui/tooltip";
 
 type SortOption = "name" | "dateCreated" | "lastCategorized" | "size";
 type NameFilterOperator = "contains" | "startsWith" | "endsWith" | "exact";
 type SizeFilterOperator = "largerThan" | "lessThan" | "between";
+type FilterType = "category" | "name" | "size";
 
 interface FilterOptions {
   categoryId: string | "uncategorized" | "";
@@ -13,6 +15,222 @@ interface FilterOptions {
   sizeOperator: SizeFilterOperator;
   sizeValue: string;
   sizeValue2: string;
+}
+
+interface ActiveFilter {
+  type: FilterType;
+  label: string;
+  value: string;
+}
+
+interface SortFilterModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  onSave: (type: "sort" | FilterType, config: any) => void;
+  editingType?: "sort" | FilterType;
+  currentSort: { option: SortOption; direction: "ascending" | "descending" };
+  currentFilters?: FilterOptions;
+  categories: Array<{ id: string; name: string; color: string }>;
+}
+
+function SortFilterModal({
+  isOpen,
+  onClose,
+  onSave,
+  editingType,
+  currentSort,
+  currentFilters,
+  categories,
+}: SortFilterModalProps) {
+  const [filterType, setFilterType] = useState<"sort" | FilterType>(editingType || "sort");
+  const [sortOption, setSortOption] = useState<SortOption>(currentSort.option);
+  const [sortDirection, setSortDirection] = useState<"ascending" | "descending">(currentSort.direction);
+  const [categoryId, setCategoryId] = useState<string>(currentFilters?.categoryId || "");
+  const [nameOperator, setNameOperator] = useState<NameFilterOperator>(currentFilters?.nameOperator || "contains");
+  const [namePattern, setNamePattern] = useState<string>(currentFilters?.namePattern || "");
+  const [sizeOperator, setSizeOperator] = useState<SizeFilterOperator>(currentFilters?.sizeOperator || "largerThan");
+  const [sizeValue, setSizeValue] = useState<string>(currentFilters?.sizeValue || "");
+  const [sizeValue2, setSizeValue2] = useState<string>(currentFilters?.sizeValue2 || "");
+
+  useEffect(() => {
+    if (editingType) {
+      setFilterType(editingType);
+    }
+  }, [editingType]);
+
+  // Sync sort values when currentSort changes (e.g., when modal opens)
+  useEffect(() => {
+    setSortOption(currentSort.option);
+    setSortDirection(currentSort.direction);
+  }, [currentSort]);
+
+  if (!isOpen) return null;
+
+  const handleSave = () => {
+    if (filterType === "sort") {
+      onSave("sort", { option: sortOption, direction: sortDirection });
+    } else if (filterType === "category") {
+      onSave("category", { categoryId });
+    } else if (filterType === "name") {
+      onSave("name", { operator: nameOperator, pattern: namePattern });
+    } else if (filterType === "size") {
+      onSave("size", { operator: sizeOperator, value: sizeValue, value2: sizeValue2 });
+    }
+    onClose();
+  };
+
+  return (
+    <div className="modal-overlay" onClick={onClose}>
+      <div className="modal-content filter-modal" onClick={(e) => e.stopPropagation()}>
+        <div className="modal-header">
+          <h2>{editingType ? "Edit" : "Add"} {filterType === "sort" ? "Sort" : "Filter"}</h2>
+          <button className="modal-close" onClick={onClose}>×</button>
+        </div>
+        <div className="modal-body">
+          {!editingType && (
+            <div className="filter-type-selector">
+              <label>Type:</label>
+              <select
+                value={filterType}
+                onChange={(e) => setFilterType(e.target.value as "sort" | FilterType)}
+                className="utility-select"
+              >
+                <option value="sort">Sort</option>
+                <option value="category">Category</option>
+                <option value="name">Name</option>
+                <option value="size">Size</option>
+              </select>
+            </div>
+          )}
+
+          {filterType === "sort" && (
+            <div className="filter-config">
+              <div className="filter-field">
+                <label>Sort by:</label>
+                <select
+                  value={sortOption}
+                  onChange={(e) => setSortOption(e.target.value as SortOption)}
+                  className="utility-select"
+                >
+                  <option value="name">Name</option>
+                  <option value="dateCreated">Date Created</option>
+                  <option value="lastCategorized">Last Categorized</option>
+                  <option value="size">Size</option>
+                </select>
+              </div>
+              <div className="filter-field">
+                <label>Direction:</label>
+                <select
+                  value={sortDirection}
+                  onChange={(e) => setSortDirection(e.target.value as "ascending" | "descending")}
+                  className="utility-select"
+                >
+                  <option value="ascending">↑ Ascending</option>
+                  <option value="descending">↓ Descending</option>
+                </select>
+              </div>
+            </div>
+          )}
+
+          {filterType === "category" && (
+            <div className="filter-config">
+              <div className="filter-field">
+                <label>Category:</label>
+                <select
+                  value={categoryId}
+                  onChange={(e) => setCategoryId(e.target.value)}
+                  className="utility-select"
+                >
+                  <option value="">All</option>
+                  <option value="uncategorized">Uncategorized</option>
+                  {categories.map((cat) => (
+                    <option key={cat.id} value={cat.id}>
+                      {cat.name}
+                    </option>
+                  ))}
+                </select>
+              </div>
+            </div>
+          )}
+
+          {filterType === "name" && (
+            <div className="filter-config">
+              <div className="filter-field">
+                <label>Operator:</label>
+                <select
+                  value={nameOperator}
+                  onChange={(e) => setNameOperator(e.target.value as NameFilterOperator)}
+                  className="utility-select"
+                >
+                  <option value="contains">Contains</option>
+                  <option value="startsWith">Starts with</option>
+                  <option value="endsWith">Ends with</option>
+                  <option value="exact">Exact</option>
+                </select>
+              </div>
+              <div className="filter-field">
+                <label>Pattern:</label>
+                <input
+                  type="text"
+                  value={namePattern}
+                  onChange={(e) => setNamePattern(e.target.value)}
+                  className="utility-input"
+                  placeholder="Enter name pattern"
+                />
+              </div>
+            </div>
+          )}
+
+          {filterType === "size" && (
+            <div className="filter-config">
+              <div className="filter-field">
+                <label>Operator:</label>
+                <select
+                  value={sizeOperator}
+                  onChange={(e) => setSizeOperator(e.target.value as SizeFilterOperator)}
+                  className="utility-select"
+                >
+                  <option value="largerThan">Larger than</option>
+                  <option value="lessThan">Less than</option>
+                  <option value="between">Between</option>
+                </select>
+              </div>
+              <div className="filter-field">
+                <label>Value (KB):</label>
+                <input
+                  type="text"
+                  value={sizeValue}
+                  onChange={(e) => setSizeValue(e.target.value)}
+                  className="utility-input"
+                  placeholder="KB"
+                />
+              </div>
+              {sizeOperator === "between" && (
+                <div className="filter-field">
+                  <label>Value 2 (KB):</label>
+                  <input
+                    type="text"
+                    value={sizeValue2}
+                    onChange={(e) => setSizeValue2(e.target.value)}
+                    className="utility-input"
+                    placeholder="KB"
+                  />
+                </div>
+              )}
+            </div>
+          )}
+        </div>
+        <div className="modal-footer">
+          <button className="utility-button utility-button-secondary" onClick={onClose}>
+            Cancel
+          </button>
+          <button className="utility-button utility-button-action" onClick={handleSave}>
+            {editingType ? "Update" : "Add"}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
 }
 
 export function ImageGridSortFilter() {
@@ -24,43 +242,32 @@ export function ImageGridSortFilter() {
   const setSortDirectionAtom = useSetAtom(sortDirectionAtom);
   const setFilterOptionsAtom = useSetAtom(filterOptionsAtom);
   
-  const [sortBy, setSortBy] = useState<SortOption>(globalSortOption);
-  const [sortDirection, setSortDirection] = useState<"ascending" | "descending">(globalSortDirection);
   const [filters, setFilters] = useState<FilterOptions>(globalFilters);
   const filterTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const [isModalOpen, setIsModalOpen] = useState(false);
+  const [editingType, setEditingType] = useState<"sort" | FilterType | undefined>();
 
   // Synchronize local state with global state changes
   useEffect(() => {
-    setSortBy(globalSortOption);
-    setSortDirection(globalSortDirection);
     setFilters(globalFilters);
-  }, [globalSortOption, globalSortDirection, globalFilters]);
-
-  // Apply sort to state immediately
-  useEffect(() => {
-    setSortOptionAtom(sortBy);
-    setSortDirectionAtom(sortDirection);
-  }, [sortBy, sortDirection, setSortOptionAtom, setSortDirectionAtom]);
+  }, [globalFilters]);
 
   // Debounced filter updater
   const updateFilters = useCallback((newFilters: FilterOptions) => {
-    // Clear any pending timeout
     if (filterTimeoutRef.current) {
       clearTimeout(filterTimeoutRef.current);
     }
 
-    // Set a new timeout to update filters after 250ms
     filterTimeoutRef.current = setTimeout(() => {
       setFilterOptionsAtom(newFilters);
       filterTimeoutRef.current = null;
     }, 250);
-  }, [setFilterOptionsAtom]);
+  }, [setFilterOptionsAtom, filterTimeoutRef]);
 
   // Apply filters to state with debounce
   useEffect(() => {
     updateFilters(filters);
     
-    // Cleanup timeout on unmount or when filters change before timeout fires
     return () => {
       if (filterTimeoutRef.current) {
         clearTimeout(filterTimeoutRef.current);
@@ -69,133 +276,202 @@ export function ImageGridSortFilter() {
     };
   }, [filters, updateFilters]);
 
-  const clearFilters = () => {
-    setFilters({
-      categoryId: "",
-      namePattern: "",
-      nameOperator: "contains",
-      sizeOperator: "largerThan",
-      sizeValue: "",
-      sizeValue2: "",
-    });
+  const getActiveFilters = (): ActiveFilter[] => {
+    const active: ActiveFilter[] = [];
+    
+    if (filters.categoryId) {
+      if (filters.categoryId === "uncategorized") {
+        active.push({ type: "category", label: "Uncategorized", value: filters.categoryId });
+      } else {
+        const category = categories.find(c => c.id === filters.categoryId);
+        active.push({ type: "category", label: category?.name || "Category", value: filters.categoryId });
+      }
+    }
+    
+    if (filters.namePattern) {
+      const operatorLabels: Record<NameFilterOperator, string> = {
+        contains: "contains",
+        startsWith: "starts with",
+        endsWith: "ends with",
+        exact: "is",
+      };
+      active.push({
+        type: "name",
+        label: `Name ${operatorLabels[filters.nameOperator]} "${filters.namePattern}"`,
+        value: filters.namePattern,
+      });
+    }
+    
+    if (filters.sizeValue) {
+      const operatorLabels: Record<SizeFilterOperator, string> = {
+        largerThan: ">",
+        lessThan: "<",
+        between: "between",
+      };
+      let label = `Size ${operatorLabels[filters.sizeOperator]} ${filters.sizeValue} KB`;
+      if (filters.sizeOperator === "between" && filters.sizeValue2) {
+        label = `Size between ${filters.sizeValue} - ${filters.sizeValue2} KB`;
+      }
+      active.push({ type: "size", label, value: filters.sizeValue });
+    }
+    
+    return active;
   };
 
-  const hasActiveFilters = Boolean(
-    filters.categoryId ||
-    filters.namePattern ||
-    filters.sizeValue
-  );
+  const getSortLabel = (): string => {
+    const optionLabels: Record<SortOption, string> = {
+      name: "Name",
+      dateCreated: "Date Created",
+      lastCategorized: "Last Categorized",
+      size: "Size",
+    };
+    const directionIcon = globalSortDirection === "ascending" ? "↑" : "↓";
+    return `${directionIcon} ${optionLabels[globalSortOption]}`;
+  };
+
+  const handleRemoveFilter = (type: FilterType) => {
+    if (type === "category") {
+      setFilters({ ...filters, categoryId: "" });
+    } else if (type === "name") {
+      setFilters({ ...filters, namePattern: "", nameOperator: "contains" });
+    } else if (type === "size") {
+      setFilters({ ...filters, sizeValue: "", sizeValue2: "", sizeOperator: "largerThan" });
+    }
+  };
+
+  const handleRemoveSort = () => {
+    setSortOptionAtom("name");
+    setSortDirectionAtom("ascending");
+  };
+
+  const handleAddClick = () => {
+    setEditingType(undefined);
+    setIsModalOpen(true);
+  };
+
+  const handleEditClick = (type: "sort" | FilterType) => {
+    setEditingType(type);
+    setIsModalOpen(true);
+  };
+
+  const handleModalSave = (type: "sort" | FilterType, config: any) => {
+    if (type === "sort") {
+      setSortOptionAtom(config.option);
+      setSortDirectionAtom(config.direction);
+    } else if (type === "category") {
+      setFilters({ ...filters, categoryId: config.categoryId });
+    } else if (type === "name") {
+      setFilters({ ...filters, nameOperator: config.operator, namePattern: config.pattern });
+    } else if (type === "size") {
+      setFilters({
+        ...filters,
+        sizeOperator: config.operator,
+        sizeValue: config.value,
+        sizeValue2: config.value2 || "",
+      });
+    }
+  };
+
+  const activeFilters = getActiveFilters();
+  const hasActiveSort = globalSortOption !== "name" || globalSortDirection !== "ascending";
 
   return (
     <div className="image-grid-sort-filter">
-      <div className="utility-row">
-        {/* Sort */}
-        <div className="utility-group">
-          <label htmlFor="sort-select" className="utility-label">Sort by:</label>
-          <select
-            id="sort-select"
-            className="utility-select"
-            value={sortBy}
-            onChange={(e) => setSortBy(e.target.value as SortOption)}
+      <div className="filter-badges-container">
+        {hasActiveSort && (
+          <button
+            className="filter-badge filter-badge-sort"
+            onClick={() => handleEditClick("sort")}
+            onKeyDown={(e) => {
+              if (e.key === "Enter" || e.key === " ") {
+                e.preventDefault();
+                handleEditClick("sort");
+              }
+            }}
+            aria-label={`Edit sort: ${getSortLabel()}`}
           >
-            <option value="name">Name</option>
-            <option value="dateCreated">Date Created</option>
-            <option value="lastCategorized">Last Categorized</option>
-            <option value="size">Size</option>
-          </select>
-          <select
-            id="sort-direction-select"
-            className="utility-select utility-select-small"
-            value={sortDirection}
-            onChange={(e) => setSortDirection(e.target.value as "ascending" | "descending")}
-            title="Sort direction"
-          >
-            <option value="ascending">↑ Asc</option>
-            <option value="descending">↓ Desc</option>
-          </select>
-        </div>
-
-        {/* Filter: Category */}
-        <div className="utility-group">
-          <label htmlFor="category-filter" className="utility-label">Filter by Category:</label>
-          <select
-            id="category-filter"
-            className="utility-select"
-            value={filters.categoryId}
-            onChange={(e) => setFilters({ ...filters, categoryId: e.target.value })}
-          >
-            <option value="">All</option>
-            <option value="uncategorized">Uncategorized</option>
-            {categories.map((cat) => (
-              <option key={cat.id} value={cat.id}>
-                {cat.name}
-              </option>
-            ))}
-          </select>
-        </div>
-
-        {/* Filter: Name */}
-        <div className="utility-group">
-          <label htmlFor="name-filter-operator" className="utility-label">Name:</label>
-          <select
-            id="name-filter-operator"
-            className="utility-select utility-select-small"
-            value={filters.nameOperator}
-            onChange={(e) => setFilters({ ...filters, nameOperator: e.target.value as NameFilterOperator })}
-          >
-            <option value="contains">Contains</option>
-            <option value="startsWith">Starts with</option>
-            <option value="endsWith">Ends with</option>
-            <option value="exact">Exact</option>
-          </select>
-          <input
-            type="text"
-            className="utility-input"
-            placeholder="Enter name pattern"
-            value={filters.namePattern}
-            onChange={(e) => setFilters({ ...filters, namePattern: e.target.value })}
-          />
-        </div>
-
-        {/* Filter: Size */}
-        <div className="utility-group">
-          <label htmlFor="size-filter-operator" className="utility-label">Size:</label>
-          <select
-            id="size-filter-operator"
-            className="utility-select utility-select-small"
-            value={filters.sizeOperator}
-            onChange={(e) => setFilters({ ...filters, sizeOperator: e.target.value as SizeFilterOperator })}
-          >
-            <option value="largerThan">Larger than</option>
-            <option value="lessThan">Less than</option>
-            <option value="between">Between</option>
-          </select>
-          <input
-            type="text"
-            className="utility-input utility-input-small"
-            placeholder="KB"
-            value={filters.sizeValue}
-            onChange={(e) => setFilters({ ...filters, sizeValue: e.target.value })}
-          />
-          {filters.sizeOperator === "between" && (
-            <input
-              type="text"
-              className="utility-input utility-input-small"
-              placeholder="KB"
-              value={filters.sizeValue2}
-              onChange={(e) => setFilters({ ...filters, sizeValue2: e.target.value })}
-            />
-          )}
-        </div>
-
-        {/* Clear Filters */}
-        {hasActiveFilters && (
-          <button className="utility-button utility-button-secondary" onClick={clearFilters}>
-            Clear Filters
+            <span className="filter-badge-label">Sort: {getSortLabel()}</span>
+            <span
+              className="filter-badge-remove"
+              role="button"
+              tabIndex={0}
+              onClick={(e) => {
+                e.stopPropagation();
+                handleRemoveSort();
+              }}
+              onKeyDown={(e) => {
+                if (e.key === "Enter" || e.key === " ") {
+                  e.preventDefault();
+                  e.stopPropagation();
+                  handleRemoveSort();
+                }
+              }}
+              title="Remove sort"
+              aria-label="Remove sort"
+            >
+              ×
+            </span>
           </button>
         )}
+        
+        {activeFilters.map((filter, index) => (
+          <button
+            key={`${filter.type}-${index}`}
+            className="filter-badge filter-badge-filter"
+            onClick={() => handleEditClick(filter.type)}
+            onKeyDown={(e) => {
+              if (e.key === "Enter" || e.key === " ") {
+                e.preventDefault();
+                handleEditClick(filter.type);
+              }
+            }}
+            aria-label={`Edit filter: ${filter.label}`}
+          >
+            <span className="filter-badge-label">{filter.label}</span>
+            <span
+              className="filter-badge-remove"
+              role="button"
+              tabIndex={0}
+              onClick={(e) => {
+                e.stopPropagation();
+                handleRemoveFilter(filter.type);
+              }}
+              onKeyDown={(e) => {
+                if (e.key === "Enter" || e.key === " ") {
+                  e.preventDefault();
+                  e.stopPropagation();
+                  handleRemoveFilter(filter.type);
+                }
+              }}
+              title="Remove filter"
+              aria-label="Remove filter"
+            >
+              ×
+            </span>
+          </button>
+        ))}
+        
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <button className="filter-badge filter-badge-add" onClick={handleAddClick}>
+              +
+            </button>
+          </TooltipTrigger>
+          <TooltipContent>
+            <p>Add sort or filter</p>
+          </TooltipContent>
+        </Tooltip>
       </div>
+
+      <SortFilterModal
+        isOpen={isModalOpen}
+        onClose={() => setIsModalOpen(false)}
+        onSave={handleModalSave}
+        editingType={editingType}
+        currentSort={{ option: globalSortOption, direction: globalSortDirection }}
+        currentFilters={filters}
+        categories={categories}
+      />
     </div>
   );
 }
-

--- a/src/components/ui/tooltip.tsx
+++ b/src/components/ui/tooltip.tsx
@@ -1,0 +1,164 @@
+import React, { useState, useRef, useEffect } from "react";
+
+interface TooltipProps {
+  children: React.ReactNode;
+  delayDuration?: number;
+}
+
+interface TooltipTriggerProps {
+  asChild?: boolean;
+  children: React.ReactElement;
+}
+
+interface TooltipContentProps {
+  children: React.ReactNode;
+  side?: "top" | "right" | "bottom" | "left";
+}
+
+const TooltipContext = React.createContext<{
+  open: boolean;
+  setOpen: (open: boolean) => void;
+}>({ open: false, setOpen: () => {} });
+
+export function Tooltip({ children, delayDuration = 300 }: TooltipProps) {
+  const [open, setOpen] = useState(false);
+  const timeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const handleOpen = () => {
+    if (timeoutRef.current) {
+      clearTimeout(timeoutRef.current);
+    }
+    timeoutRef.current = setTimeout(() => setOpen(true), delayDuration);
+  };
+
+  const handleClose = () => {
+    if (timeoutRef.current) {
+      clearTimeout(timeoutRef.current);
+      timeoutRef.current = null;
+    }
+    setOpen(false);
+  };
+
+  useEffect(() => {
+    return () => {
+      if (timeoutRef.current) {
+        clearTimeout(timeoutRef.current);
+      }
+    };
+  }, []);
+
+  return (
+    <TooltipContext.Provider value={{ open, setOpen }}>
+      <div
+        onMouseEnter={handleOpen}
+        onMouseLeave={handleClose}
+        onFocus={handleOpen}
+        onBlur={handleClose}
+        style={{ display: "inline-block", position: "relative" }}
+      >
+        {children}
+      </div>
+    </TooltipContext.Provider>
+  );
+}
+
+export function TooltipTrigger({ asChild, children }: TooltipTriggerProps) {
+  if (asChild && React.isValidElement(children)) {
+    return React.cloneElement(children, {
+      "data-tooltip-trigger": "true",
+    } as any);
+  }
+  return (
+    <div data-tooltip-trigger="true" style={{ display: "inline-block" }}>
+      {children}
+    </div>
+  );
+}
+
+export function TooltipContent({ children, side = "top" }: TooltipContentProps) {
+  const context = React.useContext(TooltipContext);
+  const [position, setPosition] = useState({ top: 0, left: 0 });
+  const contentRef = useRef<HTMLDivElement>(null);
+  const triggerRef = useRef<HTMLElement | null>(null);
+
+  useEffect(() => {
+    // Find the trigger element using the data attribute
+    const parent = contentRef.current?.parentElement;
+    if (parent) {
+      const trigger = parent.querySelector('[data-tooltip-trigger]') as HTMLElement | null;
+      triggerRef.current = trigger;
+    }
+  }, [context.open]);
+
+  useEffect(() => {
+    if (!context.open || !contentRef.current || !triggerRef.current) return;
+
+    const updatePosition = () => {
+      if (!contentRef.current || !triggerRef.current) return;
+
+      const triggerRect = triggerRef.current.getBoundingClientRect();
+      const contentRect = contentRef.current.getBoundingClientRect();
+      const parentRect = contentRef.current.parentElement?.getBoundingClientRect() || { left: 0, top: 0 };
+      const gap = 8;
+
+      let top = 0;
+      let left = 0;
+
+      // Calculate position relative to parent container
+      const triggerLeft = triggerRect.left - parentRect.left;
+      const triggerTop = triggerRect.top - parentRect.top;
+
+      switch (side) {
+        case "top":
+          top = triggerTop - contentRect.height - gap;
+          left = triggerLeft + triggerRect.width / 2 - contentRect.width / 2;
+          break;
+        case "bottom":
+          top = triggerTop + triggerRect.height + gap;
+          left = triggerLeft + triggerRect.width / 2 - contentRect.width / 2;
+          break;
+        case "left":
+          top = triggerTop + triggerRect.height / 2 - contentRect.height / 2;
+          left = triggerLeft - contentRect.width - gap;
+          break;
+        case "right":
+          top = triggerTop + triggerRect.height / 2 - contentRect.height / 2;
+          left = triggerLeft + triggerRect.width + gap;
+          break;
+      }
+
+      setPosition({ top, left });
+    };
+
+    // Small delay to ensure content is rendered
+    const timeout = setTimeout(updatePosition, 0);
+    window.addEventListener("resize", updatePosition);
+    window.addEventListener("scroll", updatePosition, true);
+    
+    return () => {
+      clearTimeout(timeout);
+      window.removeEventListener("resize", updatePosition);
+      window.removeEventListener("scroll", updatePosition, true);
+    };
+  }, [context.open, side]);
+
+  if (!context.open) return null;
+
+  return (
+    <div
+      ref={contentRef}
+      className="tooltip-content"
+      data-side={side}
+      style={{
+        position: "absolute",
+        top: `${position.top}px`,
+        left: `${position.left}px`,
+        zIndex: 1000,
+        pointerEvents: "none",
+      }}
+    >
+      {children}
+    </div>
+  );
+}
+

--- a/src/state.test.ts
+++ b/src/state.test.ts
@@ -30,6 +30,7 @@ import {
   toggleImageSelectionAtom,
   suppressCategoryRefilterAtom,
   cachedImageCategoriesForRefilterAtom,
+  sortedImagesAtom,
   resetStateAtom,
 } from './state';
 
@@ -76,6 +77,7 @@ describe('state', () => {
       expect(store.get(toggleImageSelectionAtom)).toBeUndefined();
       expect(store.get(suppressCategoryRefilterAtom)).toBe(false);
       expect(store.get(cachedImageCategoriesForRefilterAtom)).toBeNull();
+      expect(store.get(sortedImagesAtom)).toEqual([]);
     });
 
     it('should allow setting and getting values', () => {
@@ -174,6 +176,7 @@ describe('state', () => {
       expect(store.get(toggleImageSelectionAtom)).toBeUndefined();
       expect(store.get(suppressCategoryRefilterAtom)).toBe(false);
       expect(store.get(cachedImageCategoriesForRefilterAtom)).toBeNull();
+      expect(store.get(sortedImagesAtom)).toEqual([]);
     });
 
     it('should increment resetCounter on each reset', () => {

--- a/src/state.ts
+++ b/src/state.ts
@@ -56,6 +56,7 @@ export const selectedImagesAtom = atom<Set<string>>(new Set<string>());
 export const toggleImageSelectionAtom = atom<((path: string) => void) | undefined>(undefined); // Optional function to toggle image selection (set by ImageGridSelection component)
 export const suppressCategoryRefilterAtom = atom<boolean>(false); // When true, don't trigger re-filtering on category changes (used during modal assignment)
 export const cachedImageCategoriesForRefilterAtom = atom<Map<string, CategoryAssignment[]> | null>(null); // Cached snapshot of imageCategories when suppressCategoryRefilter is set
+export const sortedImagesAtom = atom<ImagePath[]>([]); // Sorted and filtered images (updated by ImageGrid, used by ImageModal for consistent indexing)
 
 // Create a write-only atom that resets all state to initial values
 export const resetStateAtom = atom(null, (get, set) => {
@@ -88,6 +89,7 @@ export const resetStateAtom = atom(null, (get, set) => {
   set(toggleImageSelectionAtom, undefined);
   set(suppressCategoryRefilterAtom, false);
   set(cachedImageCategoriesForRefilterAtom, null);
+  set(sortedImagesAtom, []);
 });
 
 // DOM Elements

--- a/src/styles.css
+++ b/src/styles.css
@@ -1081,6 +1081,41 @@ button {
   display: block;
 }
 
+.image-item-category-badges {
+  position: absolute;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 4px;
+  padding: 6px;
+  background: linear-gradient(to top, rgba(0, 0, 0, 0.7) 0%, rgba(0, 0, 0, 0.4) 70%, transparent 100%);
+  backdrop-filter: blur(4px);
+  pointer-events: none;
+  z-index: 5;
+}
+
+.image-item-category-badge {
+  display: inline-block;
+  padding: 3px 8px;
+  border-radius: 12px;
+  font-size: 0.7em;
+  font-weight: 600;
+  line-height: 1.2;
+  white-space: nowrap;
+  text-overflow: ellipsis;
+  max-width: 120px;
+  overflow: hidden;
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.3);
+  opacity: 0.95;
+  transition: opacity 0.2s ease;
+}
+
+.image-item:hover .image-item-category-badge {
+  opacity: 1;
+}
+
 .directory-item {
   background-color: #f9f9f9 !important;
   transition: all 0.2s ease;

--- a/src/styles.css
+++ b/src/styles.css
@@ -65,9 +65,24 @@ body {
   box-sizing: border-box;
 }
 
+.app-header {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  margin-bottom: 0;
+  transition: all 0.3s ease;
+  width: 100%;
+}
+
+.app-header.has-content {
+  justify-content: flex-start;
+  align-items: center;
+  padding-left: 20px;
+}
+
 h1 {
   text-align: center;
-  margin-bottom: 30px;
+  margin-bottom: 0;
   font-size: 3.5em;
   font-weight: 700;
   letter-spacing: -0.02em;
@@ -89,6 +104,16 @@ h1 {
   box-sizing: border-box;
 }
 
+.app-header.has-content h1 {
+  text-align: left;
+  font-size: 2.5em;
+  width: auto;
+  flex-shrink: 0;
+  display: flex;
+  align-items: center;
+  line-height: 1.2;
+}
+
 h1:hover {
   transform: scale(1.05);
   filter: brightness(1.1);
@@ -108,9 +133,18 @@ h1::after {
   transition: all 0.3s ease;
 }
 
+.app-header.has-content h1::after {
+  left: 0;
+  transform: translateX(0);
+}
+
 h1:hover::after {
   width: 120px;
   opacity: 1;
+}
+
+.app-header.has-content h1:hover::after {
+  width: 100px;
 }
 
 .path-input-container {
@@ -205,7 +239,20 @@ h1:hover::after {
 .current-path {
   margin-top: 15px;
   text-align: center;
-  display: none;
+  display: block;
+}
+
+.app-header .current-path {
+  margin-top: 30px;
+  display: flex;
+  align-items: flex-end;
+  margin-left: clamp(20px, 10vw, 100px);
+  min-width: 0; /* Allow flex item to shrink */
+  height: fit-content;
+}
+
+.app-header .current-path .breadcrumb {
+  justify-content: flex-start;
 }
 
 .breadcrumb {
@@ -346,7 +393,7 @@ button {
 
 .image-grid-header-row {
   display: flex;
-  align-items: flex-start;
+  align-items: center;
   justify-content: space-between;
   gap: 20px;
   flex-wrap: wrap;
@@ -362,6 +409,355 @@ button {
   display: flex;
   flex-direction: column;
   flex-shrink: 0;
+}
+
+.filter-badges-container {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  align-items: center;
+  padding: 8px 0;
+}
+
+.filter-badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 6px 12px;
+  border-radius: 16px;
+  font-size: 0.85em;
+  cursor: pointer;
+  transition: all 0.2s;
+  border: 1px solid rgba(255, 255, 255, 0.2);
+  background-color: rgba(255, 255, 255, 0.1);
+  color: #f1f1f1;
+  user-select: none;
+  /* Remove default button styles */
+  font-family: inherit;
+  text-align: left;
+}
+
+.filter-badge:focus {
+  outline: 2px solid rgba(255, 255, 255, 0.5);
+  outline-offset: 2px;
+}
+
+.filter-badge:focus:not(:focus-visible) {
+  outline: none;
+}
+
+.filter-badge:hover {
+  background-color: rgba(255, 255, 255, 0.15);
+  border-color: rgba(255, 255, 255, 0.3);
+  transform: translateY(-1px);
+}
+
+.filter-badge-sort {
+  background-color: rgba(34, 197, 94, 0.2);
+  border-color: rgba(34, 197, 94, 0.4);
+  color: #22c55e;
+}
+
+.filter-badge-sort:hover {
+  background-color: rgba(34, 197, 94, 0.3);
+  border-color: rgba(34, 197, 94, 0.5);
+}
+
+.filter-badge-filter {
+  background-color: rgba(59, 130, 246, 0.2);
+  border-color: rgba(59, 130, 246, 0.4);
+  color: #3b82f6;
+}
+
+.filter-badge-filter:hover {
+  background-color: rgba(59, 130, 246, 0.3);
+  border-color: rgba(59, 130, 246, 0.5);
+}
+
+.filter-badge-add {
+  background-color: rgba(255, 255, 255, 0.15);
+  border-color: rgba(255, 255, 255, 0.3);
+  color: #f1f1f1;
+  font-size: 1.2em;
+  font-weight: bold;
+  padding: 6px 14px;
+  min-width: 32px;
+  justify-content: center;
+}
+
+.filter-badge-add:hover {
+  background-color: rgba(255, 255, 255, 0.25);
+  border-color: rgba(255, 255, 255, 0.4);
+}
+
+.tooltip-content {
+  padding: 6px 12px;
+  background-color: #ffffff;
+  color: #0f0f0f;
+  border-radius: 6px;
+  font-size: 0.85em;
+  white-space: nowrap;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
+  animation: tooltip-fade-in 0.15s ease-out;
+  border: 1px solid rgba(0, 0, 0, 0.1);
+}
+
+.tooltip-content::before {
+  content: "";
+  position: absolute;
+  width: 0;
+  height: 0;
+  border-style: solid;
+}
+
+.tooltip-content[data-side="top"]::before {
+  bottom: -6px;
+  left: 50%;
+  transform: translateX(-50%);
+  border-width: 6px 6px 0 6px;
+  border-color: #ffffff transparent transparent transparent;
+}
+
+.tooltip-content[data-side="bottom"]::before {
+  top: -6px;
+  left: 50%;
+  transform: translateX(-50%);
+  border-width: 0 6px 6px 6px;
+  border-color: transparent transparent #ffffff transparent;
+}
+
+.tooltip-content[data-side="left"]::before {
+  right: -6px;
+  top: 50%;
+  transform: translateY(-50%);
+  border-width: 6px 0 6px 6px;
+  border-color: transparent transparent transparent #ffffff;
+}
+
+.tooltip-content[data-side="right"]::before {
+  left: -6px;
+  top: 50%;
+  transform: translateY(-50%);
+  border-width: 6px 6px 6px 0;
+  border-color: transparent #ffffff transparent transparent;
+}
+
+@keyframes tooltip-fade-in {
+  from {
+    opacity: 0;
+    transform: translateY(-2px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+.filter-badge-label {
+  white-space: nowrap;
+}
+
+.filter-badge-remove {
+  background: none;
+  border: none;
+  color: inherit;
+  font-size: 1.2em;
+  line-height: 1;
+  cursor: pointer;
+  padding: 0;
+  margin-left: 2px;
+  width: 18px;
+  height: 18px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 50%;
+  transition: all 0.2s;
+  opacity: 0.7;
+}
+
+.filter-badge-remove:hover {
+  opacity: 1;
+  background-color: rgba(0, 0, 0, 0.2);
+  transform: scale(1.1);
+}
+
+.modal-overlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background-color: rgba(0, 0, 0, 0.6);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 1000;
+  backdrop-filter: blur(4px);
+}
+
+.filter-modal {
+  background-color: rgba(30, 30, 30, 0.98);
+  border-radius: 12px;
+  box-shadow: 0 8px 32px rgba(0, 0, 0, 0.5);
+  max-width: 380px;
+  width: 30vw;
+  max-height: 90vh;
+  overflow: hidden;
+  display: flex;
+  flex-direction: column;
+  border: 1px solid rgba(255, 255, 255, 0.1);
+}
+
+.modal-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 20px;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.1);
+}
+
+.modal-header h2 {
+  margin: 0;
+  font-size: 1.2em;
+  color: #f1f1f1;
+  font-weight: 600;
+}
+
+.modal-close {
+  background: none;
+  border: none;
+  color: #f1f1f1;
+  font-size: 1.5em;
+  cursor: pointer;
+  padding: 0;
+  width: 32px;
+  height: 32px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 6px;
+  transition: all 0.2s;
+  opacity: 0.7;
+}
+
+.modal-close:hover {
+  opacity: 1;
+  background-color: rgba(255, 255, 255, 0.1);
+}
+
+.modal-body {
+  padding: 20px;
+  overflow-y: auto;
+  flex: 1;
+}
+
+.modal-footer {
+  display: flex;
+  justify-content: flex-end;
+  gap: 12px;
+  padding: 20px;
+  border-top: 1px solid rgba(255, 255, 255, 0.1);
+}
+
+.filter-type-selector {
+  margin-bottom: 20px;
+}
+
+.filter-type-selector label {
+  display: block;
+  margin-bottom: 8px;
+  font-size: 0.9em;
+  color: #f1f1f1;
+}
+
+.filter-config {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.filter-field {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.filter-field label {
+  font-size: 0.9em;
+  color: #f1f1f1;
+  font-weight: 500;
+}
+
+@media (prefers-color-scheme: light) {
+  .filter-badge {
+    background-color: rgba(0, 0, 0, 0.05);
+    border-color: rgba(0, 0, 0, 0.2);
+    color: #0f0f0f;
+  }
+
+  .filter-badge:hover {
+    background-color: rgba(0, 0, 0, 0.1);
+    border-color: rgba(0, 0, 0, 0.3);
+  }
+
+  .filter-badge-sort {
+    background-color: rgba(34, 197, 94, 0.15);
+    border-color: rgba(34, 197, 94, 0.3);
+    color: #16a34a;
+  }
+
+  .filter-badge-sort:hover {
+    background-color: rgba(34, 197, 94, 0.25);
+    border-color: rgba(34, 197, 94, 0.4);
+  }
+
+  .filter-badge-filter {
+    background-color: rgba(59, 130, 246, 0.15);
+    border-color: rgba(59, 130, 246, 0.3);
+    color: #2563eb;
+  }
+
+  .filter-badge-filter:hover {
+    background-color: rgba(59, 130, 246, 0.25);
+    border-color: rgba(59, 130, 246, 0.4);
+  }
+
+  .filter-badge-add {
+    background-color: rgba(0, 0, 0, 0.08);
+    border-color: rgba(0, 0, 0, 0.2);
+    color: #0f0f0f;
+  }
+
+  .filter-badge-add:hover {
+    background-color: rgba(0, 0, 0, 0.12);
+    border-color: rgba(0, 0, 0, 0.3);
+  }
+
+  .filter-badge-remove:hover {
+    background-color: rgba(0, 0, 0, 0.1);
+  }
+
+  .filter-modal {
+    background-color: rgba(255, 255, 255, 0.98);
+    border-color: rgba(0, 0, 0, 0.1);
+  }
+
+  .modal-header h2 {
+    color: #0f0f0f;
+  }
+
+  .modal-close {
+    color: #0f0f0f;
+  }
+
+  .modal-close:hover {
+    background-color: rgba(0, 0, 0, 0.05);
+  }
+
+  .filter-field label {
+    color: #0f0f0f;
+  }
 }
 
 .image-grid-stats {
@@ -1059,18 +1455,18 @@ button {
 /* Hotkey Sidebar */
 .hotkey-sidebar {
   position: fixed;
-  left: 0;
+  right: 0;
   top: 0;
   width: 350px;
   height: 100%;
   background-color: rgba(20, 20, 20, 0.95);
   backdrop-filter: blur(10px);
   z-index: 1002;
-  transform: translateX(-100%);
+  transform: translateX(100%);
   transition: transform 0.3s ease-out;
   display: flex;
   flex-direction: column;
-  box-shadow: 2px 0 20px rgba(0, 0, 0, 0.5);
+  box-shadow: -2px 0 20px rgba(0, 0, 0, 0.5);
 }
 
 .hotkey-sidebar.open {
@@ -1224,7 +1620,7 @@ button {
 
 .hotkey-sidebar-toggle {
   position: fixed;
-  left: 20px;
+  right: 20px;
   top: 20px;
   background-color: rgba(0, 0, 0, 0.7);
   border: 1px solid rgba(255, 255, 255, 0.2);
@@ -1278,7 +1674,7 @@ body:has(.hotkey-sidebar.open) .hotkey-sidebar-toggle .hamburger-icon {
 }
 
 body:has(.hotkey-sidebar.open) .hotkey-sidebar-toggle {
-  left: 370px;
+  right: 370px;
 }
 
 /* Scroll to Top Button */

--- a/src/ui/hotkeys.test.ts
+++ b/src/ui/hotkeys.test.ts
@@ -34,7 +34,7 @@ describe("hotkeys", () => {
   beforeEach(() => {
     // Reset DOM - create minimal elements needed for querySelector
     document.body.innerHTML = `
-      <div id="hotkeys-panel"></div>
+      <div id="hotkey-sidebar"></div>
       <img id="modal-image" />
     `;
 
@@ -111,8 +111,8 @@ describe("hotkeys", () => {
 
     it("should handle missing sidebar element gracefully", async () => {
       // Remove the sidebar element to test the missing-element path
-      const hotkeysPanel = document.getElementById("hotkeys-panel");
-      hotkeysPanel?.remove();
+      const hotkeySidebar = document.getElementById("hotkey-sidebar");
+      hotkeySidebar?.remove();
       
       const { toggleHotkeySidebar } = await import("./hotkeys");
       await expect(toggleHotkeySidebar()).resolves.not.toThrow();
@@ -142,8 +142,8 @@ describe("hotkeys", () => {
 
     it("should handle missing sidebar element gracefully", async () => {
       // Remove the sidebar element to test the missing-element path
-      const hotkeysPanel = document.getElementById("hotkeys-panel");
-      hotkeysPanel?.remove();
+      const hotkeySidebar = document.getElementById("hotkey-sidebar");
+      hotkeySidebar?.remove();
       
       const { closeHotkeySidebar } = await import("./hotkeys");
       expect(() => closeHotkeySidebar()).not.toThrow();
@@ -458,7 +458,7 @@ describe("hotkeys", () => {
       const addHotkeyBtn = document.createElement("button");
       addHotkeyBtn.id = "add-hotkey-btn";
       const sidebar = document.createElement("div");
-      sidebar.id = "hotkeys-panel";
+      sidebar.id = "hotkey-sidebar";
 
       document.body.appendChild(sidebarToggle);
       document.body.appendChild(sidebarClose);
@@ -559,7 +559,7 @@ describe("hotkeys", () => {
 
     it("should handle clicking inside sidebar without closing", async () => {
       const sidebar = document.createElement("div");
-      sidebar.id = "hotkeys-panel";
+      sidebar.id = "hotkey-sidebar";
       const innerButton = document.createElement("button");
       sidebar.appendChild(innerButton);
       document.body.appendChild(sidebar);

--- a/src/ui/hotkeys.ts
+++ b/src/ui/hotkeys.ts
@@ -15,7 +15,7 @@ export const SIDEBAR_WIDTH = "350px";
  * Toggle the hotkey sidebar visibility.
  */
 export async function toggleHotkeySidebar(): Promise<void> {
-  const hotkeySidebar = document.querySelector("#hotkeys-panel") as HTMLElement | null;
+  const hotkeySidebar = document.querySelector("#hotkey-sidebar") as HTMLElement | null;
   if (!hotkeySidebar) return;
   
   const current = store.get(isHotkeySidebarOpenAtom);
@@ -32,7 +32,7 @@ export async function toggleHotkeySidebar(): Promise<void> {
  * Close the hotkey sidebar.
  */
 export function closeHotkeySidebar(): void {
-  const hotkeySidebar = document.querySelector("#hotkeys-panel") as HTMLElement | null;
+  const hotkeySidebar = document.querySelector("#hotkey-sidebar") as HTMLElement | null;
   if (!hotkeySidebar) return;
   
   store.set(isHotkeySidebarOpenAtom, false);
@@ -313,7 +313,7 @@ export function setupHotkeySidebar(): void {
   addHotkeyBtn.onclick = () => showHotkeyDialog();
   
   // Close sidebar when clicking outside
-  const hotkeySidebar = document.querySelector("#hotkeys-panel") as HTMLElement | null;
+  const hotkeySidebar = document.querySelector("#hotkey-sidebar") as HTMLElement | null;
   if (hotkeySidebar) {
     hotkeySidebar.onclick = (e: MouseEvent) => {
       if (e.target === hotkeySidebar) {


### PR DESCRIPTION
This PR implements category badges on images in the grid and fixes the index mismatch between the grid and modal.

## Changes

### Category Badges (Resolves #21)
- Added category badge overlays at the bottom of images in the grid
- Badges show assigned category names with category colors
- Automatic contrast text color calculation for readability
- Gradient overlay ensures badges are visible over any image
- Multiple badges wrap nicely when an image has multiple categories

### Index Mismatch Fix
- Fixed issue where modal index didn't match visual grid position
- Created shared `sortedImagesAtom` for consistent indexing
- ImageGrid now writes to `sortedImagesAtom` whenever it updates sorted images
- ImageModal and modal utilities now use `sortedImagesAtom` instead of `getFilteredAndSortedImagesSync`
- Ensures both components use the same sorted list from Rust sorting

### Testing
- Updated all tests to use `sortedImagesAtom` instead of mocked `getFilteredAndSortedImagesSync`
- All 561 tests passing

## Screenshots
(Add screenshots if available)

Closes #21

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Modal-based filter and sort interface with dynamic filter badges and edit/remove controls
  * Category badges now displayed as overlays on images
  * Image statistics and breadcrumbs integrated into the header

* **UI/UX Improvements**
  * Hotkey sidebar repositioned to right side of interface
  * Enhanced header layout with improved content alignment
  * New tooltip component for contextual guidance
  * Refined filter workflow with consolidated badge management

* **Documentation**
  * Updated guides covering badge-based filtering, customizable hotkeys, and reorganized image management sections

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->