### PR TITLE
feat(ui): show sort badge when user explicitly sets sort option

### DIFF
--- a/src/components/ImageGridSortFilter.tsx
+++ b/src/components/ImageGridSortFilter.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useState, useCallback, useRef } from "react";
 import { useAtomValue, useSetAtom } from "jotai";
-import { sortOptionAtom, sortDirectionAtom, filterOptionsAtom, categoriesAtom } from "../state";
+import { sortOptionAtom, sortDirectionAtom, sortExplicitlySetAtom, filterOptionsAtom, categoriesAtom } from "../state";
 import { Tooltip, TooltipContent, TooltipTrigger } from "./ui/tooltip";
 
 type SortOption = "name" | "dateCreated" | "lastCategorized" | "size";
@@ -238,8 +238,10 @@ export function ImageGridSortFilter() {
   const globalSortDirection = useAtomValue(sortDirectionAtom);
   const globalFilters = useAtomValue(filterOptionsAtom);
   const categories = useAtomValue(categoriesAtom);
+  const sortExplicitlySet = useAtomValue(sortExplicitlySetAtom);
   const setSortOptionAtom = useSetAtom(sortOptionAtom);
   const setSortDirectionAtom = useSetAtom(sortDirectionAtom);
+  const setSortExplicitlySetAtom = useSetAtom(sortExplicitlySetAtom);
   const setFilterOptionsAtom = useSetAtom(filterOptionsAtom);
   
   const [filters, setFilters] = useState<FilterOptions>(globalFilters);
@@ -342,6 +344,7 @@ export function ImageGridSortFilter() {
   const handleRemoveSort = () => {
     setSortOptionAtom("name");
     setSortDirectionAtom("ascending");
+    setSortExplicitlySetAtom(false);
   };
 
   const handleAddClick = () => {
@@ -358,6 +361,7 @@ export function ImageGridSortFilter() {
     if (type === "sort") {
       setSortOptionAtom(config.option);
       setSortDirectionAtom(config.direction);
+      setSortExplicitlySetAtom(true);
     } else if (type === "category") {
       setFilters({ ...filters, categoryId: config.categoryId });
     } else if (type === "name") {
@@ -373,7 +377,7 @@ export function ImageGridSortFilter() {
   };
 
   const activeFilters = getActiveFilters();
-  const hasActiveSort = globalSortOption !== "name" || globalSortDirection !== "ascending";
+  const hasActiveSort = sortExplicitlySet; // Show sort badge only when user has explicitly set a sort option
 
   return (
     <div className="image-grid-sort-filter">

--- a/src/state.ts
+++ b/src/state.ts
@@ -25,6 +25,7 @@ export const isLoadingAtom = atom<boolean>(false); // Whether the loading spinne
 export const errorMessageAtom = atom<string>(""); // Current error message to display (empty = no error)
 export const sortOptionAtom = atom<"name" | "dateCreated" | "lastCategorized" | "size">("name");
 export const sortDirectionAtom = atom<"ascending" | "descending">("ascending");
+export const sortExplicitlySetAtom = atom<boolean>(false); // Whether the user has explicitly set a sort option
 
 // Shared initial filter options to avoid duplication between atom default and resetStateAtom
 const initialFilterOptions = {
@@ -83,6 +84,7 @@ export const resetStateAtom = atom(null, (get, set) => {
   set(errorMessageAtom, "");
   set(sortOptionAtom, "name");
   set(sortDirectionAtom, "ascending");
+  set(sortExplicitlySetAtom, false);
   set(filterOptionsAtom, { ...initialFilterOptions });
   set(selectionModeAtom, false);
   set(selectedImagesAtom, new Set<string>());


### PR DESCRIPTION
Fixes #36

Display the sort-filter badge whenever the user explicitly sets a sort option, even if it's the default (name, ascending). Previously, the badge was hidden for the default sort, which was confusing for users.

## Changes
- Add `sortExplicitlySetAtom` to track when user explicitly sets a sort option
- Show badge only after user explicitly sets sort option (via modal)
- Hide badge when user removes sort
- Reset flag on state reset

## Behavior
- Badge does not show initially (when sort is at default)
- Badge appears after user explicitly sets a sort option (even if it's the default)
- Badge disappears when user removes the sort badge
- Badge appears again if user sets a sort option again

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved sort interface behavior: the sort indicator badge now only displays when you explicitly set a sort preference, providing clearer visibility into intentional sorting choices rather than showing default sorting state.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->