### PR TITLE
feat(categories): add mutually exclusive categories and move config to .hito.json

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ Simply drag and drop a folder to start browsing your images.
 
 - **Category Management**: Create, edit, and delete custom categories with color coding
   - **Automatic Hotkey Assignment**: When you create a new category, a number key (1-9, then 0) is automatically assigned to toggle that category. The first available number key is used, checking in order: 1, 2, 3, 4, 5, 6, 7, 8, 9, then 0
+  - **Mutually Exclusive Categories**: Configure categories to be mutually exclusive with other categories. When assigning a category, any mutually exclusive categories are automatically removed from the image
 - **Category Assignment**: Assign multiple categories to images for flexible organization
 - **Badge-Based Filtering & Sorting**: Clean, minimal UI showing only active filters and sorts as badges
   - **Category Filtering**: Filter images by category or view uncategorized images
@@ -49,10 +50,11 @@ Simply drag and drop a folder to start browsing your images.
 
 ### Data Storage
 
-- **Hybrid Storage Architecture**:
-  - Categories and hotkeys stored in app data directory (persistent across directories)
-  - Image category assignments stored in `.hito.json` files (directory-specific)
-- **Custom Data File Paths**: Configure different data file paths for different directories
+- **Directory-Specific Configuration**:
+  - All data stored in `.hito.json` files within each directory
+  - Categories, hotkeys, and image category assignments are all stored per-directory
+  - Each directory can have its own set of categories and hotkeys
+- **Custom Data File Paths**: Configure different data file paths for different directories (stored in app data directory)
 - **Automatic Data Migration**: Seamlessly handles data file path changes and reloads
 
 ## Install
@@ -126,6 +128,7 @@ Download the installer from [the latest release](https://github.com/iomz/hito/re
 1. **Open sidebar**: Click the hamburger menu (☰) button in the top-right corner when viewing a directory. The sidebar slides in from the right.
 2. **Create categories**: Go to the "Categories" tab and click "+ Add" to create a new category
    - **Automatic hotkey**: When you create a new category, a number key (1-9, then 0) is automatically assigned to toggle that category. You can see and edit this hotkey in the "Hotkeys" tab
+   - **Mutually exclusive categories**: When creating or editing a category, you can select which other categories are mutually exclusive with it. If category A is mutually exclusive with category B, assigning A to an image will automatically remove B (and vice versa)
 3. **Assign categories**:
    - In the modal view, click category buttons to assign/unassign categories to the current image
    - Categories are saved automatically to the data file (`.hito.json`)
@@ -152,6 +155,8 @@ Download the installer from [the latest release](https://github.com/iomz/hito/re
 3. **Set custom path**: Enter a custom path for the data file (`.hito.json`) for the current directory
 4. **Save**: Click "Save" to persist the custom data file path for this directory
 
+**Note**: Categories and hotkeys are stored in the `.hito.json` file for each directory, making them directory-specific. Each directory can have its own set of categories and hotkeys.
+
 ## Default Keyboard Shortcuts
 
 ### Modal-Only Shortcuts (Built-in, Cannot be Customized)
@@ -173,6 +178,7 @@ Download the installer from [the latest release](https://github.com/iomz/hito/re
 ### Automatic Category Hotkeys
 
 When you create a new category, a number key is automatically assigned to toggle that category:
+
 - Number keys are assigned in order: `1`, `2`, `3`, `4`, `5`, `6`, `7`, `8`, `9`, then `0`
 - Only unassigned number keys (without modifiers) are used
 - If all number keys (0-9) are already assigned, no hotkey is automatically created

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "hito",
   "private": true,
-  "version": "0.3.5",
+  "version": "0.3.6",
   "type": "module",
   "scripts": {
     "tauri": "tauri",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -1437,7 +1437,7 @@ checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "hito"
-version = "0.3.5"
+version = "0.3.6"
 dependencies = [
  "base64 0.22.1",
  "chrono",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hito"
-version = "0.3.5"
+version = "0.3.6"
 description = "A Tauri App for Human Intelligence Tasks organizer"
 authors = ["iomz@sazanka.io"]
 edition = "2021"

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -31,17 +31,8 @@ function App() {
   ), [allImagePaths, allDirectoryPaths]);
 
   useEffect(() => {
-    // Create AbortController for cancelling loadAppData on unmount
-    const abortController = new AbortController();
-    const { signal } = abortController;
-    
-    // Load app data (categories and hotkeys) on startup
-    loadAppData(signal).catch((error) => {
-      // Only log error if component is still mounted
-      if (!signal.aborted) {
-        console.error('[App] Failed to load app data:', error);
-      }
-    });
+    // Categories and hotkeys are now loaded per-directory via loadHitoConfig
+    // No need to load app data on startup
     
     // Setup all event handlers after DOM is ready
     setupDocumentDragHandlers();
@@ -68,9 +59,6 @@ function App() {
     
     // Return cleanup function that will be called on unmount
     return () => {
-      // Abort loadAppData to prevent state updates after unmount
-      abortController.abort();
-      
       window.removeEventListener(CUSTOM_DRAG_EVENTS.ENTER, handleTauriDragEnter);
       window.removeEventListener(CUSTOM_DRAG_EVENTS.OVER, handleTauriDragEnter);
       window.removeEventListener(CUSTOM_DRAG_EVENTS.LEAVE, handleTauriDragLeave);

--- a/src/components/HotkeyDialog.tsx
+++ b/src/components/HotkeyDialog.tsx
@@ -3,7 +3,7 @@ import { useAtomValue, useSetAtom } from "jotai";
 import { hotkeyDialogVisibleAtom, hotkeyDialogHotkeyAtom, hotkeysAtom, categoriesAtom } from "../state";
 import type { HotkeyConfig, Category } from "../types";
 import { formatHotkeyDisplay, isHotkeyDuplicate, populateActionDropdown } from "../ui/hotkeys";
-import { saveAppData } from "../ui/categories";
+import { saveHitoConfig } from "../ui/categories";
 
 export function HotkeyDialog() {
   const isVisible = useAtomValue(hotkeyDialogVisibleAtom);
@@ -214,7 +214,7 @@ export function HotkeyDialog() {
     }
     
     try {
-      await saveAppData();
+      await saveHitoConfig();
     } catch (error: unknown) {
       console.error("Failed to save hotkeys:", error);
       setErrorMessage("Failed to save hotkey. Please try again.");

--- a/src/core/browse.test.ts
+++ b/src/core/browse.test.ts
@@ -248,6 +248,27 @@ describe("browse", () => {
       expect(store.get(allImagePathsAtom)).toEqual(contents.images);
     });
 
+    it("should load config for empty directories to prevent config leakage", async () => {
+      const contents: DirectoryContents = {
+        directories: [],
+        images: [],
+      };
+      setupBrowseMocks(contents);
+
+      // Set some state from a previous directory
+      store.set(allDirectoryPathsAtom, [{ path: "/old/dir" }]);
+      store.set(allImagePathsAtom, [{ path: "/old/image.jpg" }]);
+
+      await browseImages("/test/path");
+
+      // loadHitoConfig should be called even for empty directories
+      expect(loadHitoConfig).toHaveBeenCalled();
+      // Arrays should be cleared for empty directories
+      expect(store.get(allDirectoryPathsAtom)).toEqual([]);
+      expect(store.get(allImagePathsAtom)).toEqual([]);
+      expect(store.get(isLoadingAtom)).toBe(false);
+    });
+
     it("should handle Tauri API unavailable", async () => {
       // Mock get_data_file_path to be called before the check
       vi.mocked(invokeTauri).mockResolvedValueOnce(null); // get_data_file_path

--- a/src/core/browse.test.ts
+++ b/src/core/browse.test.ts
@@ -242,7 +242,7 @@ describe("browse", () => {
 
       expect(invokeTauri).toHaveBeenCalledWith("get_data_file_path", { directory: "/test/path" });
       expect(invokeTauri).toHaveBeenCalledWith("list_images", { path: "/test/path" });
-      expect(loadAppData).toHaveBeenCalled();
+      // loadAppData is no longer called - categories/hotkeys are loaded via loadHitoConfig
       expect(loadHitoConfig).toHaveBeenCalled();
       expect(store.get(allDirectoryPathsAtom)).toEqual(contents.directories);
       expect(store.get(allImagePathsAtom)).toEqual(contents.images);

--- a/src/core/browse.ts
+++ b/src/core/browse.ts
@@ -17,7 +17,7 @@ import { BATCH_SIZE } from "../constants";
 import type { DirectoryContents } from "../types";
 import { showNotification } from "../ui/notification";
 import { showError, clearError } from "../ui/error";
-import { loadHitoConfig, loadAppData } from "../ui/categories";
+import { loadHitoConfig } from "../ui/categories";
 import { ensureImagePathsArray } from "../utils/state";
 import { invokeTauri, isTauriInvokeAvailable } from "../utils/tauri";
 
@@ -114,10 +114,7 @@ export async function browseImages(path: string): Promise<void> {
     store.set(allDirectoryPathsAtom, directories);
     store.set(allImagePathsAtom, images);
     
-    // Load categories and hotkeys from app data directory
-    await loadAppData();
-    
-    // Load image category assignments for this directory
+    // Load image category assignments, categories, and hotkeys for this directory
     await loadHitoConfig();
     
     // Hide spinner after everything is loaded

--- a/src/core/browse.ts
+++ b/src/core/browse.ts
@@ -96,8 +96,16 @@ export async function browseImages(path: string): Promise<void> {
     const directories = Array.isArray(contents.directories) ? contents.directories : [];
     const images = Array.isArray(contents.images) ? contents.images : [];
     
+    // Load image category assignments, categories, and hotkeys for this directory,
+    // even if there are no images yet. This ensures per-directory configuration
+    // is loaded and prevents config from previous directory from leaking.
+    await loadHitoConfig();
+    
     if (images.length === 0 && directories.length === 0) {
       showNotification("No images or directories found in this directory.");
+      store.set(allDirectoryPathsAtom, []);
+      store.set(allImagePathsAtom, []);
+      store.set(currentIndexAtom, 0);
       store.set(isLoadingAtom, false);
       return;
     }
@@ -113,9 +121,6 @@ export async function browseImages(path: string): Promise<void> {
     // Now update the arrays - this will trigger ImageGrid to mount
     store.set(allDirectoryPathsAtom, directories);
     store.set(allImagePathsAtom, images);
-    
-    // Load image category assignments, categories, and hotkeys for this directory
-    await loadHitoConfig();
     
     // Hide spinner after everything is loaded
     store.set(isLoadingAtom, false);

--- a/src/styles.css
+++ b/src/styles.css
@@ -2417,6 +2417,64 @@ body:has(.hotkey-sidebar.open) .hotkey-sidebar-toggle {
   display: none;
 }
 
+.category-mutually-exclusive-list {
+  max-height: 200px;
+  overflow-y: auto;
+  border: 1px solid rgba(255, 255, 255, 0.2);
+  border-radius: 6px;
+  padding: 8px;
+  background-color: rgba(255, 255, 255, 0.05);
+}
+
+.category-mutually-exclusive-item {
+  display: flex;
+  align-items: center;
+  margin-bottom: 8px;
+  cursor: pointer;
+  padding: 4px;
+  border-radius: 4px;
+  transition: background-color 0.2s;
+}
+
+.category-mutually-exclusive-item:hover {
+  background-color: rgba(255, 255, 255, 0.05);
+}
+
+.category-mutually-exclusive-item:last-child {
+  margin-bottom: 0;
+}
+
+.category-mutually-exclusive-item input[type="checkbox"] {
+  width: 18px;
+  height: 18px;
+  cursor: pointer;
+  margin-right: 8px;
+  accent-color: #22c55e;
+}
+
+.category-mutually-exclusive-color {
+  display: inline-block;
+  width: 16px;
+  height: 16px;
+  border-radius: 3px;
+  margin-right: 8px;
+  border: 1px solid rgba(255, 255, 255, 0.2);
+  flex-shrink: 0;
+}
+
+.category-mutually-exclusive-item span:last-child {
+  color: #f1f1f1;
+  font-size: 0.9em;
+}
+
+.category-mutually-exclusive-empty {
+  color: #999;
+  font-style: italic;
+  text-align: center;
+  padding: 12px;
+  font-size: 0.85em;
+}
+
 /* Confirmation Dialog */
 .confirm-dialog-overlay {
   position: fixed;

--- a/src/types.ts
+++ b/src/types.ts
@@ -38,6 +38,7 @@ export interface Category {
   id: string;
   name: string;
   color: string; // Hex color for visual distinction
+  mutuallyExclusiveWith?: string[]; // Array of category IDs that are mutually exclusive with this category
 }
 
 export interface CategoryAssignment {

--- a/src/ui/categories.test.ts
+++ b/src/ui/categories.test.ts
@@ -1247,6 +1247,8 @@ describe("categories UI and management", () => {
         directory: "/test/dir",
         filename: undefined,
         imageCategories: Array.from(store.get(imageCategoriesAtom).entries()),
+        categories: store.get(categoriesAtom),
+        hotkeys: store.get(hotkeysAtom),
       });
     });
 
@@ -1663,19 +1665,6 @@ describe("categories UI and management", () => {
       store.set(dataFilePathAtom, "");
     });
 
-    // Categories are now loaded via loadAppData, not loadHitoConfig
-    it.skip("should handle null categories", async () => {
-      mockInvoke.mockResolvedValue({
-        categories: null,
-        image_categories: [],
-        hotkeys: [],
-      });
-
-      const { loadHitoConfig } = await import("./categories");
-      await loadHitoConfig();
-
-      expect(store.get(categoriesAtom)).toEqual([]);
-    });
 
     it("should handle null image_categories", async () => {
       mockInvoke.mockResolvedValue({
@@ -2796,8 +2785,8 @@ describe("categories UI and management", () => {
       expect(hotkeys.length).toBe(2);
       expect(hotkeys[0].key).toBe("J");
       expect(hotkeys[1].key).toBe("K");
-      // Should save default hotkeys
-      expect(mockInvoke).toHaveBeenCalledWith("save_app_data", expect.any(Object));
+      // Should save default hotkeys to .hito.json
+      expect(mockInvoke).toHaveBeenCalledWith("save_hito_config", expect.any(Object));
     });
 
     it("should handle error when saving default hotkeys fails", async () => {

--- a/src/ui/categories.ts
+++ b/src/ui/categories.ts
@@ -311,13 +311,31 @@ export async function saveHitoConfig(): Promise<void> {
       hotkeysCount: hotkeys.length,
     });
 
-    await invokeTauri("save_hito_config", {
+    // Build payload conditionally - only include categories and hotkeys if non-empty
+    const payload: {
+      directory: string;
+      imageCategories: Array<[string, CategoryAssignment[]]>;
+      filename?: string;
+      categories?: Category[];
+      hotkeys?: HotkeyConfig[];
+    } = {
       directory: dataDir,
       imageCategories: imageCategoriesArray,
-      filename: dataFileName,
-      categories: categories.length > 0 ? categories : undefined,
-      hotkeys: hotkeys.length > 0 ? hotkeys : undefined,
-    });
+    };
+
+    if (dataFileName) {
+      payload.filename = dataFileName;
+    }
+
+    if (categories.length > 0) {
+      payload.categories = categories;
+    }
+
+    if (hotkeys.length > 0) {
+      payload.hotkeys = hotkeys;
+    }
+
+    await invokeTauri("save_hito_config", payload);
 
     console.log("[saveHitoConfig] Data file saved successfully");
   } catch (error) {

--- a/src/ui/categories.ts
+++ b/src/ui/categories.ts
@@ -758,9 +758,6 @@ export async function deleteCategory(categoryId: string): Promise<void> {
     }
   });
   store.set(imageCategoriesAtom, updatedImageCategories);
-  
-  // Save the updated image category assignments to .hito.json
-  await saveHitoConfig();
 
   // Clean up hotkeys that reference this category
   const hotkeys = store.get(hotkeysAtom);
@@ -784,7 +781,8 @@ export async function deleteCategory(categoryId: string): Promise<void> {
   const categories = store.get(categoriesAtom);
   store.set(categoriesAtom, categories.filter((c) => c.id !== categoryId));
 
-  // Categories are now saved via saveHitoConfig (already called above)
+  // Persist updated image assignments, categories, and hotkeys to .hito.json
+  await saveHitoConfig();
 }
 
 /**

--- a/src/ui/hotkeys.test.ts
+++ b/src/ui/hotkeys.test.ts
@@ -12,7 +12,7 @@ import type { HotkeyConfig } from "../types";
 
 // Mock dependencies
 vi.mock("./categories", () => ({
-  saveAppData: vi.fn().mockResolvedValue(undefined),
+  saveHitoConfig: vi.fn().mockResolvedValue(undefined),
   toggleCategoryForCurrentImage: vi.fn().mockResolvedValue(undefined),
 }));
 
@@ -1076,10 +1076,10 @@ describe("hotkeys", () => {
       ]);
 
       const { confirm } = await import("../utils/dialog");
-      const { saveAppData } = await import("./categories");
+      const { saveHitoConfig } = await import("./categories");
       const { showError } = await import("./error");
       vi.mocked(confirm).mockResolvedValue(true);
-      vi.mocked(saveAppData).mockRejectedValueOnce(new Error("Save failed"));
+      vi.mocked(saveHitoConfig).mockRejectedValueOnce(new Error("Save failed"));
 
       const consoleSpy = vi.spyOn(console, "error").mockImplementation(() => {});
 
@@ -1204,7 +1204,7 @@ describe("hotkeys", () => {
         { id: "cat1", name: "Keep", color: "#22c55e" },
       ]);
       
-      const { saveAppData } = await import("./categories");
+      const { saveHitoConfig } = await import("./categories");
       const { autoAssignHotkeyToCategory } = await import("./hotkeys");
       
       const result = await autoAssignHotkeyToCategory("cat1");
@@ -1217,7 +1217,7 @@ describe("hotkeys", () => {
         modifiers: [],
         action: "toggle_category_cat1",
       });
-      expect(saveAppData).toHaveBeenCalled();
+      expect(saveHitoConfig).toHaveBeenCalled();
     });
 
     it("should assign next available key when some are taken", async () => {
@@ -1229,7 +1229,7 @@ describe("hotkeys", () => {
         { id: "cat1", name: "Keep", color: "#22c55e" },
       ]);
       
-      const { saveAppData } = await import("./categories");
+      const { saveHitoConfig } = await import("./categories");
       const { autoAssignHotkeyToCategory } = await import("./hotkeys");
       
       const result = await autoAssignHotkeyToCategory("cat1");
@@ -1243,7 +1243,7 @@ describe("hotkeys", () => {
         modifiers: [],
         action: "toggle_category_cat1",
       });
-      expect(saveAppData).toHaveBeenCalled();
+      expect(saveHitoConfig).toHaveBeenCalled();
     });
 
     it("should assign '0' when 1-9 are all taken", async () => {
@@ -1263,7 +1263,7 @@ describe("hotkeys", () => {
         { id: "cat7", name: "Archive", color: "#3b82f6" },
       ]);
       
-      const { saveAppData } = await import("./categories");
+      const { saveHitoConfig } = await import("./categories");
       const { autoAssignHotkeyToCategory } = await import("./hotkeys");
       
       const result = await autoAssignHotkeyToCategory("cat7");
@@ -1276,7 +1276,7 @@ describe("hotkeys", () => {
         modifiers: [],
         action: "toggle_category_cat7",
       });
-      expect(saveAppData).toHaveBeenCalled();
+      expect(saveHitoConfig).toHaveBeenCalled();
     });
 
     it("should return false when all number keys are assigned", async () => {
@@ -1316,8 +1316,8 @@ describe("hotkeys", () => {
         { id: "cat1", name: "Keep", color: "#22c55e" },
       ]);
       
-      const { saveAppData } = await import("./categories");
-      vi.mocked(saveAppData).mockRejectedValueOnce(new Error("Save failed"));
+      const { saveHitoConfig } = await import("./categories");
+      vi.mocked(saveHitoConfig).mockRejectedValueOnce(new Error("Save failed"));
       
       const consoleSpy = vi.spyOn(console, "error").mockImplementation(() => {});
       const { autoAssignHotkeyToCategory } = await import("./hotkeys");

--- a/src/ui/hotkeys.ts
+++ b/src/ui/hotkeys.ts
@@ -2,7 +2,7 @@ import { store } from "../utils/jotaiStore";
 import { isHotkeySidebarOpenAtom, hotkeysAtom, categoriesAtom, hotkeyDialogVisibleAtom, hotkeyDialogHotkeyAtom } from "../state";
 import { createElement } from "../utils/dom";
 import type { HotkeyConfig } from "../types";
-import { saveAppData } from "./categories";
+import { saveHitoConfig } from "./categories";
 import { confirm } from "../utils/dialog";
 import { showError } from "./error";
 
@@ -191,7 +191,7 @@ export async function deleteHotkey(hotkeyId: string): Promise<void> {
   const hotkeys = store.get(hotkeysAtom);
   store.set(hotkeysAtom, hotkeys.filter(h => h.id !== hotkeyId));
   try {
-    await saveAppData();
+    await saveHitoConfig();
   } catch (error) {
     console.error("Failed to save hotkeys:", error);
     showError("Failed to save hotkeys");
@@ -344,7 +344,7 @@ export async function autoAssignHotkeyToCategory(categoryId: string): Promise<bo
   store.set(hotkeysAtom, [...hotkeys, newHotkey]);
   
   try {
-    await saveAppData();
+    await saveHitoConfig();
     console.log(`[autoAssignHotkeyToCategory] Successfully assigned key "${unassignedKey}" to category ${categoryId}`);
     return true;
   } catch (error) {


### PR DESCRIPTION
## Description

This PR implements mutually exclusive category groups and refactors the data storage architecture to use directory-specific configuration files.

## Features

### Mutually Exclusive Categories
- Categories can be configured to be mutually exclusive with other categories
- Bidirectional mutual exclusivity (if A excludes B, B also excludes A)
- When assigning a category, mutually exclusive categories are automatically removed
- Works in both single image and batch operations
- UI shows checkboxes with indeterminate state for batch operations

### Directory-Specific Configuration
- Categories and hotkeys are now stored in `.hito.json` files (directory-specific)
- Each directory can have its own set of categories and hotkeys
- `app-config.json` now only stores data file path mappings
- Removed backward compatibility migration code

## Changes

- Added `mutuallyExclusiveWith` field to Category type
- Updated CategoryDialog to allow selecting mutually exclusive categories
- Updated category assignment logic to handle mutual exclusivity
- Refactored data storage: moved categories/hotkeys from app-config.json to .hito.json
- Updated all tests to reflect new architecture
- Updated README documentation

## Testing

- All 581 TypeScript tests pass
- All 53 Rust tests pass
- Build passes successfully

Resolves #22

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Mutually Exclusive Categories: assigning a category will automatically remove conflicting categories.
  * Per-Directory Configuration: categories, hotkeys, and image assignments are stored per-directory (.hito.json) with configurable data file paths.
  * Hotkey behavior: auto-assigned category hotkeys are shown with key+action and can be edited or removed.

* **Documentation**
  * README updated to explain per-directory storage, mutual-exclusivity behavior, and hotkey details.

* **Chores**
  * Version bumped to 0.3.6.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->